### PR TITLE
Please make junit a test-scoped dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,7 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.4</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This stops the dependency leaking into other projects when they depend on the library.

It also helps stop you using JUnit classes in production code.

You can read more about test scopes in the Maven documentation:
https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope