### PR TITLE
Fix inefficient string concatenation

### DIFF
--- a/src/com/udojava/evalex/Expression.java
+++ b/src/com/udojava/evalex/Expression.java
@@ -1114,12 +1114,13 @@ public class Expression {
 	 * @return A string with the RPN representation for this expression.
 	 */
 	public String toRPN() {
-		String result = new String();
+		StringBuffer result = new StringBuffer();
 		for (String st : getRPN()) {
-			result = result.isEmpty() ? result : result + " ";
-			result += st;
+			if (result.length() != 0)
+				result.append(" ");
+			result.append(st);
 		}
-		return result;
+		return result.toString();
 	}
 
 }


### PR DESCRIPTION
See FindBugs SBSC_USE_STRINGBUFFER_CONCATENATION

> *SBSC: Method concatenates strings using + in a loop*
The method seems to be building a String using concatenation in a loop. In each iteration, the String is converted to a StringBuffer/StringBuilder, appended to, and converted back to a String. This can lead to a cost quadratic in the number of iterations, as the growing string is recopied in each iteration.