### PR TITLE
Make ExpressionException a static class

### DIFF
--- a/src/com/udojava/evalex/Expression.java
+++ b/src/com/udojava/evalex/Expression.java
@@ -246,7 +246,7 @@ public class Expression {
 	/**
 	 * The expression evaluators exception class.
 	 */
-	public class ExpressionException extends RuntimeException {
+	public static class ExpressionException extends RuntimeException {
 		private static final long serialVersionUID = 1118142866870779047L;
 
 		public ExpressionException(String message) {


### PR DESCRIPTION
See FindBugs SIC_INNER_SHOULD_BE_STATIC

> *SIC: Should be a static inner class*
This class is an inner class, but does not use its embedded reference to the object which created it.  This reference makes the instances of the class larger, and may keep the reference to the creator object alive longer than necessary.  If possible, the class should be made static.