### PR TITLE
Add support for functions with variable numbers of parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ To include it in your Maven project, refer to the artifact in your pom:
   <tr><td>NOT(<i>expression</i>)</td><td>Boolean negation, 1 (means true) if the expression is not zero</td></tr>
   <tr><td>IF(<i>condition</i>,<i>value_if_true</i>,<i>value_if_false</i>)</td><td>Returns one value if the condition evaluates to true or the other if it evaluates to false</td></tr>
   <tr><td>RANDOM()</td><td>Produces a random number between 0 and 1</td></tr>
-  <tr><td>MIN(<i>e1</i>,<i>e2</i>)</td><td>Returns the smaller of both expressions</td></tr>
-  <tr><td>MAX(<i>e1</i>,<i>e2</i>)</td><td>Returns the bigger of both expressions</td></tr>
+  <tr><td>MIN(<i>e1</i>,<i>e2</i>, <i>...</i>)</td><td>Returns the smallest of the given expressions</td></tr>
+  <tr><td>MAX(<i>e1</i>,<i>e2</i>, <i>...</i>)</td><td>Returns the biggest of the given expressions</td></tr>
   <tr><td>ABS(<i>expression</i>)</td><td>Returns the absolute (non-negative) value of the expression</td></tr>
   <tr><td>ROUND(<i>expression</i>,precision)</td><td>Rounds a value to a certain number of digits, uses the current rounding mode</td></tr>
   <tr><td>FLOOR(<i>expression</i>)</td><td>Rounds the value down to the nearest integer</td></tr>

--- a/tests/com/udojava/evalex/TestCustoms.java
+++ b/tests/com/udojava/evalex/TestCustoms.java
@@ -36,5 +36,22 @@ public class TestCustoms {
 		
 		assertEquals("16", e.eval().toPlainString());
 	}
+	
+	@Test
+	public void testCustomFunctionVariableParameters() {
+		Expression e = new Expression("2 * average(12,4,8,2,9)");
+		e.addFunction(e.new Function("average", -1) {
+			@Override
+			public BigDecimal eval(List<BigDecimal> parameters) {
+				BigDecimal sum = new BigDecimal(0);
+				for (BigDecimal parameter : parameters) {
+					sum = sum.add(parameter);
+				}
+				return sum.divide(new BigDecimal(parameters.size()));
+			}
+		});
+		
+		assertEquals("14", e.eval().toPlainString());
+	}
 
 }

--- a/tests/com/udojava/evalex/TestEval.java
+++ b/tests/com/udojava/evalex/TestEval.java
@@ -150,6 +150,51 @@ public class TestEval {
 	}
 
 	@Test
+	public void testExpectedParameterNumbers() {
+		String err = "";
+		try {
+			Expression expression = new Expression("Random(1)");
+			expression.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Function Random expected 0 parameters, got 1", err);
+
+		try {
+			Expression expression = new Expression("SIN(1, 6)");
+			expression.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Function SIN expected 1 parameters, got 2", err);
+	}
+
+	@Test
+	public void testVariableParameterNumbers() {
+		String err = "";
+		try {
+			Expression expression = new Expression("min()");
+			expression.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("MIN requires at least one parameter", err);
+
+		assertEquals("1", new Expression("min(1)").eval().toPlainString());
+		assertEquals("1", new Expression("min(1, 2)").eval().toPlainString());
+		assertEquals("1", new Expression("min(1, 2, 3)").eval().toPlainString());
+		assertEquals("3", new Expression("max(3, 2, 1)").eval().toPlainString());
+		assertEquals("9", new Expression("max(3, 2, 1, 4, 5, 6, 7, 8, 9, 0)").eval().toPlainString());
+	}
+
+	@Test
+	public void testExtremeFunctionNesting() {
+		assertNotSame("1.5", new Expression("Random()").eval().toPlainString());
+		assertEquals("0.0002791281", new Expression("SIN(SIN(COS(23.6)))").eval().toPlainString());
+		assertEquals("-4", new Expression("MIN(0, SIN(SIN(COS(23.6))), 0-MAX(3,4,MAX(0,SIN(1))), 10)").eval().toPlainString());
+	}
+
+	@Test
 	public void testTrigonometry() {
 		assertEquals("0.5", new Expression("SIN(30)").eval().toPlainString());
 		assertEquals("0.8660254", new Expression("cos(30)").eval().toPlainString());

--- a/tests/com/udojava/evalex/TestRPN.java
+++ b/tests/com/udojava/evalex/TestRPN.java
@@ -21,8 +21,8 @@ public class TestRPN {
 	@Test
 	public void testFunctions() {
 		
-		assertEquals("23.6 SIN", new Expression("SIN(23.6)").toRPN());
-		assertEquals("-7 8 MAX", new Expression("MAX(-7,8)").toRPN());
-		assertEquals("3.7 SIN 2.6 -8.0 MAX MAX", new Expression("MAX(SIN(3.7),MAX(2.6,-8.0))").toRPN());
+		assertEquals("( 23.6 SIN", new Expression("SIN(23.6)").toRPN());
+		assertEquals("( -7 8 MAX", new Expression("MAX(-7,8)").toRPN());
+		assertEquals("( ( 3.7 SIN ( 2.6 -8.0 MAX MAX", new Expression("MAX(SIN(3.7),MAX(2.6,-8.0))").toRPN());
 	}
 }


### PR DESCRIPTION
 * Implementation based on "David's method" outlined in Gene Pavlovsky's comment here: http://www.kallisti.net.nz/blog/2008/02/extension-to-the-shunting-yard-algorithm-to-allow-variable-numbers-of-arguments-to-functions/#comment-125789
 * Modifies the RPN representation by adding a ( token to denote the start of a function's parameter list
 * Made MIN and MAX take a variable number of parameters
 * Closes #48 

---

Needs review for sure. I mostly just wanted to see if I could get it to work and didn't really make sure I was implementing everything in the most proper way. Let me know if there's anything that can/should be improved. One thing I think can definitely be improved is the wording of the exceptions that were added.

Note this also has the side benefit of providing better feedback about unexpected numbers of function parameters, as it can now be known how many parameters were given to a specific function and that can be compared to the expected number.