### PR TITLE
Numbers using scientific notation #51

### DIFF
--- a/src/com/udojava/evalex/Expression.java
+++ b/src/com/udojava/evalex/Expression.java
@@ -597,6 +597,8 @@ public class Expression {
                                                 || ch == 'e' || ch == 'E'
                                                 || (ch == minusSign && token.length() > 0 
                                                     && ('e'==token.charAt(token.length()-1) || 'E'==token.charAt(token.length()-1)))
+                                                || (ch == '+' && token.length() > 0 
+                                                    && ('e'==token.charAt(token.length()-1) || 'E'==token.charAt(token.length()-1)))
                                                 ) && (pos < input.length())) {
 					token.append(input.charAt(pos++));
 					ch = pos == input.length() ? 0 : input.charAt(pos);
@@ -1031,13 +1033,13 @@ public class Expression {
 	 * @return <code>true</code>, if the input string is a number.
 	 */
 	private boolean isNumber(String st) {
-		if (st.charAt(0) == minusSign && st.length() == 1)
-			return false;
+		if (st.charAt(0) == minusSign && st.length() == 1) return false;
+		if (st.charAt(0) == '+' && st.length() == 1) return false;
 		if (st.charAt(0) == 'e' ||  st.charAt(0) == 'E') return false;
 		for (char ch : st.toCharArray()) {
 			if (!Character.isDigit(ch) && ch != minusSign
 					&& ch != decimalSeparator
-                                        && ch != 'e' && ch != 'E')
+                                        && ch != 'e' && ch != 'E' && ch != '+')
 				return false;
 		}
 		return true;

--- a/src/com/udojava/evalex/Expression.java
+++ b/src/com/udojava/evalex/Expression.java
@@ -593,8 +593,11 @@ public class Expression {
 				ch = input.charAt(++pos);
 			}
 			if (Character.isDigit(ch)) {
-				while ((Character.isDigit(ch) || ch == decimalSeparator)
-						&& (pos < input.length())) {
+				while ((Character.isDigit(ch) || ch == decimalSeparator
+                                                || ch == 'e' || ch == 'E'
+                                                || (ch == minusSign && token.length() > 0 
+                                                    && ('e'==token.charAt(token.length()-1) || 'E'==token.charAt(token.length()-1)))
+                                                ) && (pos < input.length())) {
 					token.append(input.charAt(pos++));
 					ch = pos == input.length() ? 0 : input.charAt(pos);
 				}
@@ -1030,9 +1033,11 @@ public class Expression {
 	private boolean isNumber(String st) {
 		if (st.charAt(0) == minusSign && st.length() == 1)
 			return false;
+		if (st.charAt(0) == 'e' ||  st.charAt(0) == 'E') return false;
 		for (char ch : st.toCharArray()) {
 			if (!Character.isDigit(ch) && ch != minusSign
-					&& ch != decimalSeparator)
+					&& ch != decimalSeparator
+                                        && ch != 'e' && ch != 'E')
 				return false;
 		}
 		return true;

--- a/tests/com/udojava/evalex/AllTests.java
+++ b/tests/com/udojava/evalex/AllTests.java
@@ -7,6 +7,6 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({ TestTokenizer.class, TestRPN.class, TestEval.class,
 		TestVariables.class, TestBooleans.class, TestCustoms.class,
-		TestNested.class, TestVarArgs.class })
+		TestNested.class, TestVarArgs.class, TestSciNotation.class })
 public class AllTests {
 }

--- a/tests/com/udojava/evalex/TestSciNotation.java
+++ b/tests/com/udojava/evalex/TestSciNotation.java
@@ -1,0 +1,93 @@
+package com.udojava.evalex;
+
+import static org.junit.Assert.*;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+
+import org.junit.Test;
+import org.junit.Ignore;
+
+public class TestSciNotation {
+
+	@Test
+	public void testSimple() {
+		Expression e = new Expression("1e10");
+		assertEquals("10000000000", e.eval().toPlainString());
+		
+		e = new Expression("1E10");
+		assertEquals("10000000000", e.eval().toPlainString());
+		
+		e = new Expression("123.456E3");
+		assertEquals("123456", e.eval().toPlainString());
+		
+		e = new Expression("2.5e0");
+		assertEquals("2.5", e.eval().toPlainString());
+	}
+
+	@Test
+	public void testNegative() {
+		Expression e = new Expression("1e-10");
+		assertEquals("0.0000000001", e.eval().toPlainString());
+		
+		e = new Expression("1E-10");
+		assertEquals("0.0000000001", e.eval().toPlainString());
+		
+		e = new Expression("2135E-4");
+		assertEquals("0.2135", e.eval().toPlainString());
+	}
+		
+	@Test //@Ignore("Expected Failures: not implemented yet")
+	public void testPositive() {
+		Expression e = new Expression("1e+10");
+		assertEquals("10000000000", e.eval().toPlainString());
+		
+		e = new Expression("1E+10");
+		assertEquals("10000000000", e.eval().toPlainString());
+	}
+
+	@Test
+	public void testCombined() {
+		Expression e = new Expression("sqrt(152.399025e6)", MathContext.DECIMAL64);
+		assertEquals("12345", e.eval().toPlainString());
+		
+		e = new Expression("sin(3.e1)");
+		assertEquals("0.5", e.eval().toPlainString());
+		
+		e = new Expression("sin( 3.e1)");
+		assertEquals("0.5", e.eval().toPlainString());
+		
+		e = new Expression("sin(3.e1 )");
+		assertEquals("0.5", e.eval().toPlainString());
+		
+		e = new Expression("sin( 3.e1 )");
+		assertEquals("0.5", e.eval().toPlainString());
+		
+		e = new Expression("2.2e-16 * 10.2");;
+		assertEquals("2.244E-15", e.eval().toString());
+	}
+	
+	@Test(expected=NumberFormatException.class)
+	public void testError1() {
+		Expression e = new Expression("1234e-2.3");
+		e.eval();
+	}
+	
+	@Test(expected=NumberFormatException.class)
+	public void testError2() {
+		Expression e = new Expression("1234e2.3");
+		e.eval();
+	}
+	
+	@Test
+	public void testError3() {
+		String err = "";
+		Expression e = new Expression("e2");
+		try {
+			e.eval();
+		} catch (RuntimeException ex) {
+			err = ex.getMessage();
+		}
+		assertEquals("Unknown operator or function: e2", err);
+	}
+}


### PR DESCRIPTION
Support scientific notation. See #51.

The tokenizer is changed, such that it accepts numbers containing 'e'. The actual parsing is done by the java method call new BigDecimal(numberstring), which accepts numbers in scientific notation.
