### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ To include it in your Maven project, refer to the artifact in your pom:
 </dependencies>
 ````
 
+If you're using gradle add to your project's app build.gradle:
+````xml
+dependencies {
+    ...
+    compile 'com.udojava:EvalEx:1.0'
+}
+````
+
 ### Usage Examples
 
 ````java


### PR DESCRIPTION
Hello, I had to add this to an Android Application I'm working on and discovered that the dependency import is only in the example for maven projects, just adding this in case someone does not know that they can use a maven dependency in gradle if it is stored in mavencentral. 

Regards,
Alejandro