### PR TITLE
Fixes #80: Make Operator and Function classes static

### DIFF
--- a/src/com/udojava/evalex/Expression.java
+++ b/src/com/udojava/evalex/Expression.java
@@ -451,7 +451,7 @@ public class Expression {
 		BigDecimal eval();
 	}
 
-	public abstract class LazyFunction {
+	public static abstract class LazyFunction {
 		/**
 		 * Name of this function.
 		 */
@@ -497,7 +497,7 @@ public class Expression {
 	 * defined by a name, the number of parameters and the actual processing
 	 * implementation.
 	 */
-	public abstract class Function extends LazyFunction {
+	public static abstract class Function extends LazyFunction {
 
 		public Function(String name, int numParams) {
 			super(name, numParams);

--- a/src/com/udojava/evalex/Expression.java
+++ b/src/com/udojava/evalex/Expression.java
@@ -530,7 +530,7 @@ public class Expression {
 	 * Abstract definition of a supported operator. An operator is defined by
 	 * its name (pattern), precedence and if it is left- or right associative.
 	 */
-	public abstract class Operator {
+	public static abstract class Operator {
 		/**
 		 * This operators name (pattern).
 		 */

--- a/tests/com/udojava/evalex/TestCaseInsensitive.java
+++ b/tests/com/udojava/evalex/TestCaseInsensitive.java
@@ -36,7 +36,7 @@ public class TestCaseInsensitive {
 
         Expression expression = new Expression("a+testsum(1,3)");
         expression.setVariable("A", new BigDecimal(1));
-        expression.addFunction(expression.new Function("testSum",-1){
+        expression.addFunction(new Expression.Function("testSum",-1){
             @Override
             public BigDecimal eval(List<BigDecimal> parameters) {
                 BigDecimal value =null;

--- a/tests/com/udojava/evalex/TestCustoms.java
+++ b/tests/com/udojava/evalex/TestCustoms.java
@@ -26,7 +26,7 @@ public class TestCustoms {
 	@Test
 	public void testCustomFunction() {
 		Expression e = new Expression("2 * average(12,4,8)");
-		e.addFunction(e.new Function("average", 3) {
+		e.addFunction(new Expression.Function("average", 3) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
 				BigDecimal sum = parameters.get(0).add(parameters.get(1)).add(parameters.get(2));
@@ -40,7 +40,7 @@ public class TestCustoms {
 	@Test
 	public void testCustomFunctionVariableParameters() {
 		Expression e = new Expression("2 * average(12,4,8,2,9)");
-		e.addFunction(e.new Function("average", -1) {
+		e.addFunction(new Expression.Function("average", -1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
 				BigDecimal sum = new BigDecimal(0);

--- a/tests/com/udojava/evalex/TestCustoms.java
+++ b/tests/com/udojava/evalex/TestCustoms.java
@@ -13,7 +13,7 @@ public class TestCustoms {
 	public void testCustomOperator() {
 		Expression e = new Expression("2.1234 >> 2");
 		
-		e.addOperator(e.new Operator(">>", 30, true) {
+		e.addOperator(new Expression.Operator(">>", 30, true) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
 				return v1.movePointRight(v2.toBigInteger().intValue());

--- a/tests/com/udojava/evalex/TestExposedComponents.java
+++ b/tests/com/udojava/evalex/TestExposedComponents.java
@@ -40,7 +40,7 @@ public class TestExposedComponents {
     public void testDeclaredFunctionGetter() {
         Expression expression = new Expression("a+b");
         int originalFunctionCount = expression.getDeclaredFunctions().size();
-        expression.addFunction(expression.new Function("func1", 3) {
+        expression.addFunction(new Expression.Function("func1", 3) {
             @Override
             public BigDecimal eval(List<BigDecimal> parameters) {
                 return null;

--- a/tests/com/udojava/evalex/TestExposedComponents.java
+++ b/tests/com/udojava/evalex/TestExposedComponents.java
@@ -16,7 +16,7 @@ public class TestExposedComponents {
     public void testDeclaredOperators() {
         Expression expression = new Expression("c+d");
         int originalOperator = expression.getDeclaredOperators().size();
-        expression.addOperator(expression.new Operator("$$", -1, true) {
+        expression.addOperator(new Expression.Operator("$$", -1, true) {
             @Override
             public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
                 return null;

--- a/tests/com/udojava/evalex/TestVarArgs.java
+++ b/tests/com/udojava/evalex/TestVarArgs.java
@@ -66,7 +66,7 @@ public class TestVarArgs {
 	@Test
 	public void testCustomFunction1() {
 		Expression e = new Expression("3 * AVG(2,4)");
-		e.addFunction(e.new Function("AVG", -1) {
+		e.addFunction(new Expression.Function("AVG", -1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
 				if (parameters.size() == 0) {
@@ -86,7 +86,7 @@ public class TestVarArgs {
 	@Test
 	public void testCustomFunction2() {
 		Expression e = new Expression("4 * AVG(2,4,6,8,10,12)");
-		e.addFunction(e.new Function("AVG", -1) {
+		e.addFunction(new Expression.Function("AVG", -1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
 				if (parameters.size() == 0) {


### PR DESCRIPTION
By making the inner classes static, custom functions can now be defined outside of the context of an Expression object.

For example, one could create subclasses of Function as top-level classes that are singletons, and expose these to Expressions.

Additional enhancements later may allow for Java8 method references to be used directly as Functions.