### PR TITLE
Allow legal variable characters to be modified

### DIFF
--- a/src/com/udojava/evalex/Expression.java
+++ b/src/com/udojava/evalex/Expression.java
@@ -381,8 +381,18 @@ public class Expression {
 	 * The {@link MathContext} to use for calculations.
 	 */
 	private MathContext mc = null;
-	
-  /**
+
+	/**
+	 * The characters (other than letters and digits) allowed as the first character in a variable.
+	 */
+	private String firstVarChars = "_";
+
+	/**
+	 * The characters (other than letters and digits) allowed as the second or subsequent characters in a variable.
+	 */
+	private String varChars = "_";
+
+	/**
 	 * The original infix expression.
 	 */
 	private final String originalExpression;
@@ -662,8 +672,8 @@ public class Expression {
 				token.append(minusSign);
 				pos++;
 				token.append(next());
-			} else if (Character.isLetter(ch) || (ch == '_')) {
-				while ((Character.isLetter(ch) || Character.isDigit(ch) || (ch == '_'))
+			} else if (Character.isLetter(ch) || firstVarChars.indexOf(ch) >= 0) {
+				while ((Character.isLetter(ch) || Character.isDigit(ch) || varChars.indexOf(ch) >= 0)
 						&& (pos < input.length())) {
 					token.append(input.charAt(pos++));
 					ch = pos == input.length() ? 0 : input.charAt(pos);
@@ -1277,6 +1287,32 @@ public class Expression {
 	 */
 	public Expression setRoundingMode(RoundingMode roundingMode) {
 		this.mc = new MathContext(mc.getPrecision(), roundingMode);
+		return this;
+	}
+
+	/**
+	 * Sets the characters other than letters and digits that are valid as the
+	 * first character of a variable.
+	 *
+	 * @param chars
+	 *            The new set of variable characters.
+	 * @return The expression, allows to chain methods.
+	 */
+	public Expression setFirstVariableCharacters(String chars) {
+		this.firstVarChars = chars;
+		return this;
+	}
+
+	/**
+	 * Sets the characters other than letters and digits that are valid as the
+	 * second and subsequent characters of a variable.
+	 *
+	 * @param chars
+	 *            The new set of variable characters.
+	 * @return The expression, allows to chain methods.
+	 */
+	public Expression setVariableCharacters(String chars) {
+		this.varChars = chars;
 		return this;
 	}
 

--- a/tests/com/udojava/evalex/AllTests.java
+++ b/tests/com/udojava/evalex/AllTests.java
@@ -9,6 +9,6 @@ import org.junit.runners.Suite.SuiteClasses;
 		TestVariables.class, TestBooleans.class, TestCustoms.class,
 		TestNested.class, TestVarArgs.class, TestSciNotation.class,
 		TestExposedComponents.class, TestCaseInsensitive.class,
-		TestLazyIf.class, TestGetUsedVariables.class })
+		TestLazyIf.class, TestGetUsedVariables.class, TestVariableCharacters.class })
 public class AllTests {
 }

--- a/tests/com/udojava/evalex/TestVariableCharacters.java
+++ b/tests/com/udojava/evalex/TestVariableCharacters.java
@@ -1,0 +1,60 @@
+package com.udojava.evalex;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestVariableCharacters {
+
+	@Test
+	public void testBadVarChar() {
+		String err = "";
+		try {
+			Expression expression = new Expression("a.b/2*PI+MIN(e,b)");
+			expression.eval();
+		} catch (Expression.ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Unknown operator '.' at position 2", err);
+	}
+
+	@Test
+	public void testAddedVarChar() {
+		String err = "";
+		Expression expression;
+
+		try {
+			expression = new Expression("a.b/2*PI+MIN(e,b)").setVariableCharacters("_");
+			expression.eval();
+		} catch (Expression.ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Unknown operator '.' at position 2", err);
+
+		try {
+			expression = new Expression("a.b/2*PI+MIN(e,b)").setVariableCharacters("_.");
+			expression.eval();
+		} catch (Expression.ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Unknown operator or function: a.b", err);
+
+		expression = new Expression("a.b/2*PI+MIN(e,b)").setVariableCharacters("_.");
+		assertEquals("5.859875", expression.with("a.b", "2").and("b", "3").eval().toPlainString());
+
+		try {
+			expression = new Expression(".a.b/2*PI+MIN(e,b)").setVariableCharacters("_.");
+			expression.eval();
+		} catch (Expression.ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Unknown operator '.' at position 1", err);
+
+		expression = new Expression("a.b/2*PI+MIN(e,b)").setVariableCharacters("_.").setFirstVariableCharacters(".");
+		assertEquals("5.859875", expression.with("a.b", "2").and("b", "3").eval().toPlainString());
+	}
+}

--- a/tests/com/udojava/evalex/TestVariableCharacters.java
+++ b/tests/com/udojava/evalex/TestVariableCharacters.java
@@ -1,60 +1,355 @@
 package com.udojava.evalex;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import java.math.RoundingMode;
+
 import org.junit.Test;
 
-import java.math.BigDecimal;
-import java.util.List;
+import com.udojava.evalex.Expression.ExpressionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
-public class TestVariableCharacters {
-
+public class TestEval {
+	
 	@Test
-	public void testBadVarChar() {
+	public void testInvalidExpressions1() {
 		String err = "";
 		try {
-			Expression expression = new Expression("a.b/2*PI+MIN(e,b)");
+			Expression expression = new Expression("12 18 2");
 			expression.eval();
-		} catch (Expression.ExpressionException e) {
+		} catch (ExpressionException e) {
 			err = e.getMessage();
 		}
-		assertEquals("Unknown operator '.' at position 2", err);
+
+		assertEquals("Too many numbers or variables", err);
 	}
 
 	@Test
-	public void testAddedVarChar() {
+	public void testInvalidExpressions2() {
 		String err = "";
-		Expression expression;
-
 		try {
-			expression = new Expression("a.b/2*PI+MIN(e,b)").setVariableCharacters("_");
+			Expression expression = new Expression("(12)(18)");
 			expression.eval();
-		} catch (Expression.ExpressionException e) {
+		} catch (ExpressionException e) {
 			err = e.getMessage();
 		}
-		assertEquals("Unknown operator '.' at position 2", err);
 
-		try {
-			expression = new Expression("a.b/2*PI+MIN(e,b)").setVariableCharacters("_.");
-			expression.eval();
-		} catch (Expression.ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Unknown operator or function: a.b", err);
-
-		expression = new Expression("a.b/2*PI+MIN(e,b)").setVariableCharacters("_.");
-		assertEquals("5.859875", expression.with("a.b", "2").and("b", "3").eval().toPlainString());
-
-		try {
-			expression = new Expression(".a.b/2*PI+MIN(e,b)").setVariableCharacters("_.");
-			expression.eval();
-		} catch (Expression.ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Unknown operator '.' at position 1", err);
-
-		expression = new Expression("a.b/2*PI+MIN(e,b)").setVariableCharacters("_.").setFirstVariableCharacters(".");
-		assertEquals("5.859875", expression.with("a.b", "2").and("b", "3").eval().toPlainString());
+		assertEquals("Too many numbers or variables", err);
 	}
+
+	@Test
+	public void testInvalidExpressions3() {
+		String err = "";
+		try {
+			Expression expression = new Expression("12 + * 18");
+			expression.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+
+		assertEquals("Missing parameter(s) for operator +", err);
+	}
+
+	@Test
+	public void testInvalidExpressions4() {
+		String err = "";
+		try {
+			Expression expression = new Expression("");
+			expression.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+
+		assertEquals("Empty expression", err);
+	}
+	
+	@Test
+	public void testWrongBrackets1() {
+		String err = "";
+		try {
+			Expression expression = new Expression("2*3(5*3)");
+			expression.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Missing operator at character position 4", err);
+	}
+	
+	@Test
+	public void testWrongBrackets2() {
+		String err = "";
+		try {
+			Expression expression = new Expression("2*(3((5*3)))");
+			expression.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Missing operator at character position 5", err);
+	}
+	
+	@Test
+	public void testBrackets() {
+		assertEquals("3", new Expression("(1+2)").eval().toPlainString());
+		assertEquals("3", new Expression("((1+2))").eval().toPlainString());
+		assertEquals("3", new Expression("(((1+2)))").eval().toPlainString());
+		assertEquals("9", new Expression("(1+2)*(1+2)").eval().toPlainString());
+		assertEquals("10", new Expression("(1+2)*(1+2)+1").eval().toPlainString());
+		assertEquals("12", new Expression("(1+2)*((1+2)+1)").eval().toPlainString());
+	}
+	
+	@Test(expected = RuntimeException.class)
+	public void testUnknow1() {
+		assertEquals("", new Expression("7#9").eval().toPlainString());
+	}
+	
+	@Test(expected = RuntimeException.class)
+	public void testUnknow2() {
+		assertEquals("", new Expression("123.6*-9.8-7#9").eval().toPlainString());
+	}
+	
+	@Test
+	public void testSimple() {
+		assertEquals("3", new Expression("1+2").eval().toPlainString());
+		assertEquals("2", new Expression("4/2").eval().toPlainString());
+		assertEquals("5", new Expression("3+4/2").eval().toPlainString());
+		assertEquals("3.5", new Expression("(3+4)/2").eval().toPlainString());
+		assertEquals("7.98", new Expression("4.2*1.9").eval().toPlainString());
+		assertEquals("2", new Expression("8%3").eval().toPlainString());
+		assertEquals("0", new Expression("8%2").eval().toPlainString());
+	}
+	
+	@Test
+	public void testPow() {
+		assertEquals("16", new Expression("2^4").eval().toPlainString());
+		assertEquals("256", new Expression("2^8").eval().toPlainString());
+		assertEquals("9", new Expression("3^2").eval().toPlainString());
+		assertEquals("6.25", new Expression("2.5^2").eval().toPlainString());
+		assertEquals("28.34045", new Expression("2.6^3.5").eval().toPlainString());
+	}
+	
+	@Test
+	public void testSqrt() {
+		assertEquals("4", new Expression("SQRT(16)").eval().toPlainString());
+		assertEquals("1.4142135", new Expression("SQRT(2)").eval().toPlainString());
+		assertEquals("1.41421356237309504880168872420969807856967187537694807317667973799073247846210703885038753432764157273501384623091229702492483605", new Expression("SQRT(2)").setPrecision(128).eval().toPlainString());
+		assertEquals("2.2360679", new Expression("SQRT(5)").eval().toPlainString());
+		assertEquals("99.3730345", new Expression("SQRT(9875)").eval().toPlainString());
+		assertEquals("2.3558437", new Expression("SQRT(5.55)").eval().toPlainString());	
+		assertEquals("0", new Expression("SQRT(0)").eval().toPlainString());
+	}
+	
+	@Test
+	public void testFunctions() {
+		assertNotSame("1.5", new Expression("Random()").eval().toPlainString());
+		assertEquals("0.400349", new Expression("SIN(23.6)").eval().toPlainString());
+		assertEquals("8", new Expression("MAX(-7,8)").eval().toPlainString());
+		assertEquals("5", new Expression("MAX(3,max(4,5))").eval().toPlainString());
+		assertEquals("9.6", new Expression("MAX(3,max(MAX(9.6,-4.2),Min(5,9)))").eval().toPlainString());
+		assertEquals("2.302585", new Expression("LOG(10)").eval().toPlainString());
+	}
+
+	@Test
+	public void testExpectedParameterNumbers() {
+		String err = "";
+		try {
+			Expression expression = new Expression("Random(1)");
+			expression.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Function Random expected 0 parameters, got 1", err);
+
+		try {
+			Expression expression = new Expression("SIN(1, 6)");
+			expression.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Function SIN expected 1 parameters, got 2", err);
+	}
+
+	@Test
+	public void testVariableParameterNumbers() {
+		String err = "";
+		try {
+			Expression expression = new Expression("min()");
+			expression.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("MIN requires at least one parameter", err);
+
+		assertEquals("1", new Expression("min(1)").eval().toPlainString());
+		assertEquals("1", new Expression("min(1, 2)").eval().toPlainString());
+		assertEquals("1", new Expression("min(1, 2, 3)").eval().toPlainString());
+		assertEquals("3", new Expression("max(3, 2, 1)").eval().toPlainString());
+		assertEquals("9", new Expression("max(3, 2, 1, 4, 5, 6, 7, 8, 9, 0)").eval().toPlainString());
+	}
+
+	@Test
+	public void testOrphanedOperators() {
+		String err = "";
+		try {
+			new Expression("/").eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Missing parameter(s) for operator /", err);
+
+		err = "";
+		try {
+			new Expression("3/").eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Missing parameter(s) for operator /", err);
+
+		err = "";
+		try {
+			new Expression("/3").eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Missing parameter(s) for operator /", err);
+
+		err = "";
+		try {
+			new Expression("SIN(MAX(23,45,12))/").eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Missing parameter(s) for operator /", err);
+
+		err = "";
+		try {
+			new Expression("+SIN(MAX(23,45,12))").eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Missing parameter(s) for operator +", err);
+	}
+
+	@Test
+	public void testOrphanedOperatorsInFunctionParameters() {
+		String err = "";
+		try {
+			new Expression("min(/)").eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Missing parameter(s) for operator / at character position 4", err);
+
+		err = "";
+		try {
+			new Expression("min(3/)").eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Missing parameter(s) for operator / at character position 5", err);
+
+		err = "";
+		try {
+			new Expression("min(/3)").eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Missing parameter(s) for operator / at character position 4", err);
+
+		err = "";
+		try {
+			new Expression("SIN(MAX(23,45,12,23.6/))").eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Missing parameter(s) for operator / at character position 21", err);
+
+		err = "";
+		try {
+			new Expression("SIN(MAX(23,45,12/,23.6))").eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Missing parameter(s) for operator / at character position 16", err);
+
+		err = "";
+		try {
+			new Expression("SIN(MAX(23,45,>=12,23.6))").eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Missing parameter(s) for operator >= at character position 14", err);
+
+		err = "";
+		try {
+			new Expression("SIN(MAX(>=23,45,12,23.6))").eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Missing parameter(s) for operator >= at character position 8", err);
+	}
+
+	@Test
+	public void testExtremeFunctionNesting() {
+		assertNotSame("1.5", new Expression("Random()").eval().toPlainString());
+		assertEquals("0.0002791281", new Expression("SIN(SIN(COS(23.6)))").eval().toPlainString());
+		assertEquals("-4", new Expression("MIN(0, SIN(SIN(COS(23.6))), 0-MAX(3,4,MAX(0,SIN(1))), 10)").eval().toPlainString());
+	}
+
+	@Test
+	public void testTrigonometry() {
+		assertEquals("0.5", new Expression("SIN(30)").eval().toPlainString());
+		assertEquals("0.8660254", new Expression("cos(30)").eval().toPlainString());
+		assertEquals("0.5773503", new Expression("TAN(30)").eval().toPlainString());
+		assertEquals("5343237000000", new Expression("SINH(30)").eval().toPlainString());
+		assertEquals("5343237000000", new Expression("COSH(30)").eval().toPlainString());
+		assertEquals("1", new Expression("TANH(30)").eval().toPlainString());
+		assertEquals("0.5235988", new Expression("RAD(30)").eval().toPlainString());
+		assertEquals("1718.873", new Expression("DEG(30)").eval().toPlainString());
+		
+	}
+	
+	@Test
+	public void testMinMaxAbs() {
+		assertEquals("3.78787", new Expression("MAX(3.78787,3.78786)").eval().toPlainString());
+		assertEquals("3.78787", new Expression("max(3.78786,3.78787)").eval().toPlainString());
+		assertEquals("3.78786", new Expression("MIN(3.78787,3.78786)").eval().toPlainString());
+		assertEquals("3.78786", new Expression("Min(3.78786,3.78787)").eval().toPlainString());
+		assertEquals("2.123", new Expression("aBs(-2.123)").eval().toPlainString());
+		assertEquals("2.123", new Expression("abs(2.123)").eval().toPlainString());
+	}
+	
+	@Test
+	public void testRounding() {
+		assertEquals("3.8", new Expression("round(3.78787,1)").eval().toPlainString());
+		assertEquals("3.788", new Expression("round(3.78787,3)").eval().toPlainString());
+		assertEquals("3.734", new Expression("round(3.7345,3)").eval().toPlainString());
+		assertEquals("-3.734", new Expression("round(-3.7345,3)").eval().toPlainString());
+		assertEquals("-3.79", new Expression("round(-3.78787,2)").eval().toPlainString());
+		assertEquals("123.79", new Expression("round(123.78787,2)").eval().toPlainString());
+		assertEquals("3", new Expression("floor(3.78787)").eval().toPlainString());
+		assertEquals("4", new Expression("ceiling(3.78787)").eval().toPlainString());
+		assertEquals("-3", new Expression("floor(-2.1)").eval().toPlainString());
+		assertEquals("-2", new Expression("ceiling(-2.1)").eval().toPlainString());
+	}
+	
+	@Test
+	public void testMathContext() {
+		Expression e = null;
+		e = new Expression("2.5/3").setPrecision(2);
+		assertEquals("0.83", e.eval().toPlainString());
+		
+		e = new Expression("2.5/3").setPrecision(3);
+		assertEquals("0.833", e.eval().toPlainString());
+		
+		e = new Expression("2.5/3").setPrecision(8);
+		assertEquals("0.83333333", e.eval().toPlainString());
+		
+		e = new Expression("2.5/3").setRoundingMode(RoundingMode.DOWN);
+		assertEquals("0.8333333", e.eval().toPlainString());
+		
+		e = new Expression("2.5/3").setRoundingMode(RoundingMode.UP);
+		assertEquals("0.8333334", e.eval().toPlainString());
+	}
+	
 }

--- a/tests/com/udojava/evalex/TestVariableCharacters.java
+++ b/tests/com/udojava/evalex/TestVariableCharacters.java
@@ -1,355 +1,60 @@
 package com.udojava.evalex;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-
-import java.math.RoundingMode;
-
 import org.junit.Test;
 
-import com.udojava.evalex.Expression.ExpressionException;
+import java.math.BigDecimal;
+import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-public class TestEval {
-	
+public class TestVariableCharacters {
+
 	@Test
-	public void testInvalidExpressions1() {
+	public void testBadVarChar() {
 		String err = "";
 		try {
-			Expression expression = new Expression("12 18 2");
+			Expression expression = new Expression("a.b/2*PI+MIN(e,b)");
 			expression.eval();
-		} catch (ExpressionException e) {
+		} catch (Expression.ExpressionException e) {
 			err = e.getMessage();
 		}
-
-		assertEquals("Too many numbers or variables", err);
+		assertEquals("Unknown operator '.' at position 2", err);
 	}
 
 	@Test
-	public void testInvalidExpressions2() {
+	public void testAddedVarChar() {
 		String err = "";
+		Expression expression;
+
 		try {
-			Expression expression = new Expression("(12)(18)");
+			expression = new Expression("a.b/2*PI+MIN(e,b)").setVariableCharacters("_");
 			expression.eval();
-		} catch (ExpressionException e) {
+		} catch (Expression.ExpressionException e) {
 			err = e.getMessage();
 		}
+		assertEquals("Unknown operator '.' at position 2", err);
 
-		assertEquals("Too many numbers or variables", err);
-	}
-
-	@Test
-	public void testInvalidExpressions3() {
-		String err = "";
 		try {
-			Expression expression = new Expression("12 + * 18");
+			expression = new Expression("a.b/2*PI+MIN(e,b)").setVariableCharacters("_.");
 			expression.eval();
-		} catch (ExpressionException e) {
+		} catch (Expression.ExpressionException e) {
 			err = e.getMessage();
 		}
+		assertEquals("Unknown operator or function: a.b", err);
 
-		assertEquals("Missing parameter(s) for operator +", err);
-	}
+		expression = new Expression("a.b/2*PI+MIN(e,b)").setVariableCharacters("_.");
+		assertEquals("5.859875", expression.with("a.b", "2").and("b", "3").eval().toPlainString());
 
-	@Test
-	public void testInvalidExpressions4() {
-		String err = "";
 		try {
-			Expression expression = new Expression("");
+			expression = new Expression(".a.b/2*PI+MIN(e,b)").setVariableCharacters("_.");
 			expression.eval();
-		} catch (ExpressionException e) {
+		} catch (Expression.ExpressionException e) {
 			err = e.getMessage();
 		}
+		assertEquals("Unknown operator '.' at position 1", err);
 
-		assertEquals("Empty expression", err);
+		expression = new Expression("a.b/2*PI+MIN(e,b)").setVariableCharacters("_.").setFirstVariableCharacters(".");
+		assertEquals("5.859875", expression.with("a.b", "2").and("b", "3").eval().toPlainString());
 	}
-	
-	@Test
-	public void testWrongBrackets1() {
-		String err = "";
-		try {
-			Expression expression = new Expression("2*3(5*3)");
-			expression.eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Missing operator at character position 4", err);
-	}
-	
-	@Test
-	public void testWrongBrackets2() {
-		String err = "";
-		try {
-			Expression expression = new Expression("2*(3((5*3)))");
-			expression.eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Missing operator at character position 5", err);
-	}
-	
-	@Test
-	public void testBrackets() {
-		assertEquals("3", new Expression("(1+2)").eval().toPlainString());
-		assertEquals("3", new Expression("((1+2))").eval().toPlainString());
-		assertEquals("3", new Expression("(((1+2)))").eval().toPlainString());
-		assertEquals("9", new Expression("(1+2)*(1+2)").eval().toPlainString());
-		assertEquals("10", new Expression("(1+2)*(1+2)+1").eval().toPlainString());
-		assertEquals("12", new Expression("(1+2)*((1+2)+1)").eval().toPlainString());
-	}
-	
-	@Test(expected = RuntimeException.class)
-	public void testUnknow1() {
-		assertEquals("", new Expression("7#9").eval().toPlainString());
-	}
-	
-	@Test(expected = RuntimeException.class)
-	public void testUnknow2() {
-		assertEquals("", new Expression("123.6*-9.8-7#9").eval().toPlainString());
-	}
-	
-	@Test
-	public void testSimple() {
-		assertEquals("3", new Expression("1+2").eval().toPlainString());
-		assertEquals("2", new Expression("4/2").eval().toPlainString());
-		assertEquals("5", new Expression("3+4/2").eval().toPlainString());
-		assertEquals("3.5", new Expression("(3+4)/2").eval().toPlainString());
-		assertEquals("7.98", new Expression("4.2*1.9").eval().toPlainString());
-		assertEquals("2", new Expression("8%3").eval().toPlainString());
-		assertEquals("0", new Expression("8%2").eval().toPlainString());
-	}
-	
-	@Test
-	public void testPow() {
-		assertEquals("16", new Expression("2^4").eval().toPlainString());
-		assertEquals("256", new Expression("2^8").eval().toPlainString());
-		assertEquals("9", new Expression("3^2").eval().toPlainString());
-		assertEquals("6.25", new Expression("2.5^2").eval().toPlainString());
-		assertEquals("28.34045", new Expression("2.6^3.5").eval().toPlainString());
-	}
-	
-	@Test
-	public void testSqrt() {
-		assertEquals("4", new Expression("SQRT(16)").eval().toPlainString());
-		assertEquals("1.4142135", new Expression("SQRT(2)").eval().toPlainString());
-		assertEquals("1.41421356237309504880168872420969807856967187537694807317667973799073247846210703885038753432764157273501384623091229702492483605", new Expression("SQRT(2)").setPrecision(128).eval().toPlainString());
-		assertEquals("2.2360679", new Expression("SQRT(5)").eval().toPlainString());
-		assertEquals("99.3730345", new Expression("SQRT(9875)").eval().toPlainString());
-		assertEquals("2.3558437", new Expression("SQRT(5.55)").eval().toPlainString());	
-		assertEquals("0", new Expression("SQRT(0)").eval().toPlainString());
-	}
-	
-	@Test
-	public void testFunctions() {
-		assertNotSame("1.5", new Expression("Random()").eval().toPlainString());
-		assertEquals("0.400349", new Expression("SIN(23.6)").eval().toPlainString());
-		assertEquals("8", new Expression("MAX(-7,8)").eval().toPlainString());
-		assertEquals("5", new Expression("MAX(3,max(4,5))").eval().toPlainString());
-		assertEquals("9.6", new Expression("MAX(3,max(MAX(9.6,-4.2),Min(5,9)))").eval().toPlainString());
-		assertEquals("2.302585", new Expression("LOG(10)").eval().toPlainString());
-	}
-
-	@Test
-	public void testExpectedParameterNumbers() {
-		String err = "";
-		try {
-			Expression expression = new Expression("Random(1)");
-			expression.eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Function Random expected 0 parameters, got 1", err);
-
-		try {
-			Expression expression = new Expression("SIN(1, 6)");
-			expression.eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Function SIN expected 1 parameters, got 2", err);
-	}
-
-	@Test
-	public void testVariableParameterNumbers() {
-		String err = "";
-		try {
-			Expression expression = new Expression("min()");
-			expression.eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("MIN requires at least one parameter", err);
-
-		assertEquals("1", new Expression("min(1)").eval().toPlainString());
-		assertEquals("1", new Expression("min(1, 2)").eval().toPlainString());
-		assertEquals("1", new Expression("min(1, 2, 3)").eval().toPlainString());
-		assertEquals("3", new Expression("max(3, 2, 1)").eval().toPlainString());
-		assertEquals("9", new Expression("max(3, 2, 1, 4, 5, 6, 7, 8, 9, 0)").eval().toPlainString());
-	}
-
-	@Test
-	public void testOrphanedOperators() {
-		String err = "";
-		try {
-			new Expression("/").eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Missing parameter(s) for operator /", err);
-
-		err = "";
-		try {
-			new Expression("3/").eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Missing parameter(s) for operator /", err);
-
-		err = "";
-		try {
-			new Expression("/3").eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Missing parameter(s) for operator /", err);
-
-		err = "";
-		try {
-			new Expression("SIN(MAX(23,45,12))/").eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Missing parameter(s) for operator /", err);
-
-		err = "";
-		try {
-			new Expression("+SIN(MAX(23,45,12))").eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Missing parameter(s) for operator +", err);
-	}
-
-	@Test
-	public void testOrphanedOperatorsInFunctionParameters() {
-		String err = "";
-		try {
-			new Expression("min(/)").eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Missing parameter(s) for operator / at character position 4", err);
-
-		err = "";
-		try {
-			new Expression("min(3/)").eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Missing parameter(s) for operator / at character position 5", err);
-
-		err = "";
-		try {
-			new Expression("min(/3)").eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Missing parameter(s) for operator / at character position 4", err);
-
-		err = "";
-		try {
-			new Expression("SIN(MAX(23,45,12,23.6/))").eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Missing parameter(s) for operator / at character position 21", err);
-
-		err = "";
-		try {
-			new Expression("SIN(MAX(23,45,12/,23.6))").eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Missing parameter(s) for operator / at character position 16", err);
-
-		err = "";
-		try {
-			new Expression("SIN(MAX(23,45,>=12,23.6))").eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Missing parameter(s) for operator >= at character position 14", err);
-
-		err = "";
-		try {
-			new Expression("SIN(MAX(>=23,45,12,23.6))").eval();
-		} catch (ExpressionException e) {
-			err = e.getMessage();
-		}
-		assertEquals("Missing parameter(s) for operator >= at character position 8", err);
-	}
-
-	@Test
-	public void testExtremeFunctionNesting() {
-		assertNotSame("1.5", new Expression("Random()").eval().toPlainString());
-		assertEquals("0.0002791281", new Expression("SIN(SIN(COS(23.6)))").eval().toPlainString());
-		assertEquals("-4", new Expression("MIN(0, SIN(SIN(COS(23.6))), 0-MAX(3,4,MAX(0,SIN(1))), 10)").eval().toPlainString());
-	}
-
-	@Test
-	public void testTrigonometry() {
-		assertEquals("0.5", new Expression("SIN(30)").eval().toPlainString());
-		assertEquals("0.8660254", new Expression("cos(30)").eval().toPlainString());
-		assertEquals("0.5773503", new Expression("TAN(30)").eval().toPlainString());
-		assertEquals("5343237000000", new Expression("SINH(30)").eval().toPlainString());
-		assertEquals("5343237000000", new Expression("COSH(30)").eval().toPlainString());
-		assertEquals("1", new Expression("TANH(30)").eval().toPlainString());
-		assertEquals("0.5235988", new Expression("RAD(30)").eval().toPlainString());
-		assertEquals("1718.873", new Expression("DEG(30)").eval().toPlainString());
-		
-	}
-	
-	@Test
-	public void testMinMaxAbs() {
-		assertEquals("3.78787", new Expression("MAX(3.78787,3.78786)").eval().toPlainString());
-		assertEquals("3.78787", new Expression("max(3.78786,3.78787)").eval().toPlainString());
-		assertEquals("3.78786", new Expression("MIN(3.78787,3.78786)").eval().toPlainString());
-		assertEquals("3.78786", new Expression("Min(3.78786,3.78787)").eval().toPlainString());
-		assertEquals("2.123", new Expression("aBs(-2.123)").eval().toPlainString());
-		assertEquals("2.123", new Expression("abs(2.123)").eval().toPlainString());
-	}
-	
-	@Test
-	public void testRounding() {
-		assertEquals("3.8", new Expression("round(3.78787,1)").eval().toPlainString());
-		assertEquals("3.788", new Expression("round(3.78787,3)").eval().toPlainString());
-		assertEquals("3.734", new Expression("round(3.7345,3)").eval().toPlainString());
-		assertEquals("-3.734", new Expression("round(-3.7345,3)").eval().toPlainString());
-		assertEquals("-3.79", new Expression("round(-3.78787,2)").eval().toPlainString());
-		assertEquals("123.79", new Expression("round(123.78787,2)").eval().toPlainString());
-		assertEquals("3", new Expression("floor(3.78787)").eval().toPlainString());
-		assertEquals("4", new Expression("ceiling(3.78787)").eval().toPlainString());
-		assertEquals("-3", new Expression("floor(-2.1)").eval().toPlainString());
-		assertEquals("-2", new Expression("ceiling(-2.1)").eval().toPlainString());
-	}
-	
-	@Test
-	public void testMathContext() {
-		Expression e = null;
-		e = new Expression("2.5/3").setPrecision(2);
-		assertEquals("0.83", e.eval().toPlainString());
-		
-		e = new Expression("2.5/3").setPrecision(3);
-		assertEquals("0.833", e.eval().toPlainString());
-		
-		e = new Expression("2.5/3").setPrecision(8);
-		assertEquals("0.83333333", e.eval().toPlainString());
-		
-		e = new Expression("2.5/3").setRoundingMode(RoundingMode.DOWN);
-		assertEquals("0.8333333", e.eval().toPlainString());
-		
-		e = new Expression("2.5/3").setRoundingMode(RoundingMode.UP);
-		assertEquals("0.8333334", e.eval().toPlainString());
-	}
-	
 }


### PR DESCRIPTION
Added 2 fields (and setters) to Expression, firstVarCharacters and varCharacters that specify the legal characters for the first character and subsequent characters of a variable in addition to letters and numbers. By default, the only legal character for both is "_", the same as before.
Added tests that use both setters.