### PR TITLE
Fix 2 bugs in firstVarChars

### DIFF
--- a/src/com/udojava/evalex/Expression.java
+++ b/src/com/udojava/evalex/Expression.java
@@ -673,7 +673,8 @@ public class Expression {
 				pos++;
 				token.append(next());
 			} else if (Character.isLetter(ch) || firstVarChars.indexOf(ch) >= 0) {
-				while ((Character.isLetter(ch) || Character.isDigit(ch) || varChars.indexOf(ch) >= 0)
+				while ((Character.isLetter(ch) || Character.isDigit(ch)
+						|| varChars.indexOf(ch) >= 0 || token.length() == 0 && firstVarChars.indexOf(ch) >= 0)
 						&& (pos < input.length())) {
 					token.append(input.charAt(pos++));
 					ch = pos == input.length() ? 0 : input.charAt(pos);
@@ -683,7 +684,7 @@ public class Expression {
 				pos++;
 			} else {
 				while (!Character.isLetter(ch) && !Character.isDigit(ch)
-						&& ch != '_' && !Character.isWhitespace(ch)
+						&& firstVarChars.indexOf(ch) < 0 && !Character.isWhitespace(ch)
 						&& ch != '(' && ch != ')' && ch != ','
 						&& (pos < input.length())) {
 					token.append(input.charAt(pos));

--- a/tests/com/udojava/evalex/TestVariableCharacters.java
+++ b/tests/com/udojava/evalex/TestVariableCharacters.java
@@ -57,4 +57,11 @@ public class TestVariableCharacters {
 		expression = new Expression("a.b/2*PI+MIN(e,b)").setVariableCharacters("_.").setFirstVariableCharacters(".");
 		assertEquals("5.859875", expression.with("a.b", "2").and("b", "3").eval().toPlainString());
 	}
+
+	@Test
+	public void testFirstVarChar() {
+		Expression expression = new Expression("a.b*$PI").setVariableCharacters(".").setFirstVariableCharacters("$");
+		assertEquals("6", expression.with("a.b", "2").and("$PI", "3").eval().toPlainString());
+
+	}
 }


### PR DESCRIPTION
1. Handle when an operator is adjacent to a char in firstVarChars that's not in the default set.
2. Handle when a var starts with a char in firstVarChars that's not in varChars.
See testFirstVarChar for both.

Sorry for missing these before.