### PR TITLE
Support null as value

### DIFF
--- a/src/com/udojava/evalex/Expression.java
+++ b/src/com/udojava/evalex/Expression.java
@@ -747,36 +747,42 @@ public class Expression {
 		addOperator(new Operator("+", 20, true) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.add(v2, mc);
 			}
 		});
 		addOperator(new Operator("-", 20, true) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.subtract(v2, mc);
 			}
 		});
 		addOperator(new Operator("*", 30, true) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.multiply(v2, mc);
 			}
 		});
 		addOperator(new Operator("/", 30, true) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.divide(v2, mc);
 			}
 		});
 		addOperator(new Operator("%", 30, true) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.remainder(v2, mc);
 			}
 		});
 		addOperator(new Operator("^", 40, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				/*- 
 				 * Thanks to Gene Marin:
 				 * http://stackoverflow.com/questions/3579779/how-to-do-a-fractional-power-on-bigdecimal-in-java
@@ -801,6 +807,7 @@ public class Expression {
 		addOperator(new Operator("&&", 4, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				boolean b1 = !v1.equals(BigDecimal.ZERO);
 				boolean b2 = !v2.equals(BigDecimal.ZERO);
 				return b1 && b2 ? BigDecimal.ONE : BigDecimal.ZERO;
@@ -810,6 +817,7 @@ public class Expression {
 		addOperator(new Operator("||", 2, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				boolean b1 = !v1.equals(BigDecimal.ZERO);
 				boolean b2 = !v2.equals(BigDecimal.ZERO);
 				return b1 || b2 ? BigDecimal.ONE : BigDecimal.ZERO;
@@ -819,6 +827,7 @@ public class Expression {
 		addOperator(new Operator(">", 10, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.compareTo(v2) == 1 ? BigDecimal.ONE : BigDecimal.ZERO;
 			}
 		});
@@ -826,6 +835,7 @@ public class Expression {
 		addOperator(new Operator(">=", 10, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.compareTo(v2) >= 0 ? BigDecimal.ONE : BigDecimal.ZERO;
 			}
 		});
@@ -833,6 +843,7 @@ public class Expression {
 		addOperator(new Operator("<", 10, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.compareTo(v2) == -1 ? BigDecimal.ONE
 						: BigDecimal.ZERO;
 			}
@@ -841,6 +852,7 @@ public class Expression {
 		addOperator(new Operator("<=", 10, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.compareTo(v2) <= 0 ? BigDecimal.ONE : BigDecimal.ZERO;
 			}
 		});
@@ -848,6 +860,12 @@ public class Expression {
 		addOperator(new Operator("=", 7, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				if (v1 == v2) {
+					return BigDecimal.ONE;
+				}
+				if (v1 == null  || v2 == null) {
+					return BigDecimal.ZERO;
+				}
 				return v1.compareTo(v2) == 0 ? BigDecimal.ONE : BigDecimal.ZERO;
 			}
 		});
@@ -861,12 +879,19 @@ public class Expression {
 		addOperator(new Operator("!=", 7, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				if (v1 == v2) {
+					return BigDecimal.ZERO;
+				}
+				if (v1 == null  || v2 == null) {
+					return BigDecimal.ONE;
+				}
 				return v1.compareTo(v2) != 0 ? BigDecimal.ONE : BigDecimal.ZERO;
 			}
 		});
 		addOperator(new Operator("<>", 7, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return operators.get("!=").eval(v1, v2);
 			}
 		});
@@ -874,6 +899,7 @@ public class Expression {
 		addFunction(new Function("NOT", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				boolean zero = parameters.get(0).compareTo(BigDecimal.ZERO) == 0;
 				return zero ? BigDecimal.ONE : BigDecimal.ZERO;
 			}
@@ -882,7 +908,9 @@ public class Expression {
 		addLazyFunction(new LazyFunction("IF", 3) {
 			@Override
 			public LazyNumber lazyEval(List<LazyNumber> lazyParams) {
-				boolean isTrue = !lazyParams.get(0).eval().equals(BigDecimal.ZERO);
+				BigDecimal result = lazyParams.get(0).eval();
+				assertNotNull(result);
+				boolean isTrue = !result.equals(BigDecimal.ZERO);
 				return isTrue ? lazyParams.get(1) : lazyParams.get(2);
 			}
 		});
@@ -897,6 +925,7 @@ public class Expression {
 		addFunction(new Function("SIN", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.sin(Math.toRadians(parameters.get(0)
 						.doubleValue()));
 				return new BigDecimal(d, mc);
@@ -905,6 +934,7 @@ public class Expression {
 		addFunction(new Function("COS", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.cos(Math.toRadians(parameters.get(0)
 						.doubleValue()));
 				return new BigDecimal(d, mc);
@@ -913,6 +943,7 @@ public class Expression {
 		addFunction(new Function("TAN", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.tan(Math.toRadians(parameters.get(0)
 						.doubleValue()));
 				return new BigDecimal(d, mc);
@@ -921,6 +952,7 @@ public class Expression {
 		addFunction(new Function("ASIN", 1) { // added by av
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.toDegrees(Math.asin(parameters.get(0)
 						.doubleValue()));
 				return new BigDecimal(d, mc);
@@ -929,6 +961,7 @@ public class Expression {
 		addFunction(new Function("ACOS", 1) { // added by av
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.toDegrees(Math.acos(parameters.get(0)
 						.doubleValue()));
 				return new BigDecimal(d, mc);
@@ -937,6 +970,7 @@ public class Expression {
 		addFunction(new Function("ATAN", 1) { // added by av
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.toDegrees(Math.atan(parameters.get(0)
 						.doubleValue()));
 				return new BigDecimal(d, mc);
@@ -945,6 +979,7 @@ public class Expression {
 		addFunction(new Function("SINH", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.sinh(parameters.get(0).doubleValue());
 				return new BigDecimal(d, mc);
 			}
@@ -952,6 +987,7 @@ public class Expression {
 		addFunction(new Function("COSH", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.cosh(parameters.get(0).doubleValue());
 				return new BigDecimal(d, mc);
 			}
@@ -959,6 +995,7 @@ public class Expression {
 		addFunction(new Function("TANH", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.tanh(parameters.get(0).doubleValue());
 				return new BigDecimal(d, mc);
 			}
@@ -966,6 +1003,7 @@ public class Expression {
 		addFunction(new Function("RAD", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.toRadians(parameters.get(0).doubleValue());
 				return new BigDecimal(d, mc);
 			}
@@ -973,6 +1011,7 @@ public class Expression {
 		addFunction(new Function("DEG", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.toDegrees(parameters.get(0).doubleValue());
 				return new BigDecimal(d, mc);
 			}
@@ -985,6 +1024,7 @@ public class Expression {
 				}
 				BigDecimal max = null;
 				for (BigDecimal parameter : parameters) {
+					assertNotNull(parameter);
 					if (max == null || parameter.compareTo(max) > 0) {
 						max = parameter;
 					}
@@ -1000,6 +1040,7 @@ public class Expression {
 				}
 				BigDecimal min = null;
 				for (BigDecimal parameter : parameters) {
+					assertNotNull(parameter);
 					if (min == null || parameter.compareTo(min) < 0) {
 						min = parameter;
 					}
@@ -1010,12 +1051,14 @@ public class Expression {
 		addFunction(new Function("ABS", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				return parameters.get(0).abs(mc);
 			}
 		});
 		addFunction(new Function("LOG", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.log(parameters.get(0).doubleValue());
 				return new BigDecimal(d, mc);
 			}
@@ -1023,6 +1066,7 @@ public class Expression {
 		addFunction(new Function("LOG10", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.log10(parameters.get(0).doubleValue());
 				return new BigDecimal(d, mc);
 			}
@@ -1030,6 +1074,7 @@ public class Expression {
 		addFunction(new Function("ROUND", 2) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0), parameters.get(1));
 				BigDecimal toRound = parameters.get(0);
 				int precision = parameters.get(1).intValue();
 				return toRound.setScale(precision, mc.getRoundingMode());
@@ -1038,6 +1083,7 @@ public class Expression {
 		addFunction(new Function("FLOOR", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				BigDecimal toRound = parameters.get(0);
 				return toRound.setScale(0, RoundingMode.FLOOR);
 			}
@@ -1045,6 +1091,7 @@ public class Expression {
 		addFunction(new Function("CEILING", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				BigDecimal toRound = parameters.get(0);
 				return toRound.setScale(0, RoundingMode.CEILING);
 			}
@@ -1052,6 +1099,7 @@ public class Expression {
 		addFunction(new Function("SQRT", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				/*
 				 * From The Java Programmers Guide To numerical Computing
 				 * (Ronald Mak, 2003)
@@ -1084,9 +1132,25 @@ public class Expression {
 
 		variables.put("e", e);
 		variables.put("PI", PI);
+		variables.put("NULL", null);
 		variables.put("TRUE", BigDecimal.ONE);
 		variables.put("FALSE", BigDecimal.ZERO);
 
+	}
+	
+	private void assertNotNull(BigDecimal v1) {
+		if (v1 == null) {
+			throw new ArithmeticException("Operand may not be null");
+		}
+	}
+	
+	private void assertNotNull(BigDecimal v1, BigDecimal v2) {
+		if (v1 == null) {
+			throw new ArithmeticException("First operand may not be null");
+		}
+		if (v2 == null) {
+			throw new ArithmeticException("Second operand may not be null");
+		}		
 	}
 
 	/**
@@ -1236,7 +1300,8 @@ public class Expression {
 			} else if (variables.containsKey(token)) {
 				stack.push(new LazyNumber() {
 					public BigDecimal eval() {
-						return variables.get(token).round(mc);
+						BigDecimal value = variables.get(token);
+						return value == null ? null : value.round(mc);
 					}
 				});
 			} else if (functions.containsKey(token.toUpperCase(Locale.ROOT))) {
@@ -1258,12 +1323,16 @@ public class Expression {
 			} else {
 				stack.push(new LazyNumber() {
 					public BigDecimal eval() {
+						if (token.equalsIgnoreCase("NULL")) {
+							return null;
+						}
 						return new BigDecimal(token, mc);
 					}
 				});
 			}
 		}
-		return stack.pop().eval().stripTrailingZeros();
+		BigDecimal result = stack.pop().eval();
+		return result == null ? null : result.stripTrailingZeros();
 	}
 
 	/**
@@ -1379,6 +1448,9 @@ public class Expression {
 	public Expression setVariable(String variable, String value) {
 		if (isNumber(value))
 			variables.put(variable, new BigDecimal(value));
+		else if (value.equalsIgnoreCase("null")) {
+			variables.put(variable, null);
+		}
 		else {
 			expression = expression.replaceAll("(?i)\\b" + variable + "\\b", "("
 					+ value + ")");

--- a/tests/com/udojava/evalex/TestEval.java
+++ b/tests/com/udojava/evalex/TestEval.java
@@ -352,4 +352,47 @@ public class TestEval {
 		assertEquals("0.8333334", e.eval().toPlainString());
 	}
 	
+	@Test
+	public void testNull() {
+		Expression e = null;
+		e = new Expression("null");
+		assertEquals(null, e.eval());
+	}
+	
+	@Test
+	public void testCalculationWithNull() {
+		String err = "";
+		try {
+			new Expression("null+1").eval();
+		} catch (ArithmeticException e) {
+			err = e.getMessage();
+		}
+		assertEquals("First operand may not be null",err);
+		
+		err = "";
+		try {
+			new Expression("1 + NULL").eval();
+		} catch (ArithmeticException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Second operand may not be null",err);
+		
+		err = "";
+		try {
+			new Expression("round(Null, 1)").eval();
+		} catch (ArithmeticException e) {
+			err = e.getMessage();
+		}
+		assertEquals("First operand may not be null",err);
+
+		err = "";
+		try {
+			new Expression("round(1, NulL)").eval();
+		} catch (ArithmeticException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Second operand may not be null",err);
+	}
+
+	
 }

--- a/tests/com/udojava/evalex/TestLazyIf.java
+++ b/tests/com/udojava/evalex/TestLazyIf.java
@@ -3,6 +3,8 @@ package com.udojava.evalex;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 import java.math.BigDecimal;
 
 /**
@@ -18,4 +20,16 @@ public class TestLazyIf {
         Assert.assertEquals(expression.eval(),new BigDecimal(0));
 
     }
+    
+    @Test
+    public void testLazyIfWithNull() {
+		String err = "";
+		try {
+        	new Expression("if(a,0,12/a)").setVariable("a", "null").eval();
+		} catch (ArithmeticException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Operand may not be null",err);
+    }
+
 }

--- a/tests/com/udojava/evalex/TestVariables.java
+++ b/tests/com/udojava/evalex/TestVariables.java
@@ -83,4 +83,22 @@ public class TestVariables {
 				new Expression("3*_longname1").with("_longname1", new BigDecimal("7"))
 						.eval().toString());		
 	}
+	
+	@Test
+	public void testNullVariable() {
+		Expression e = null;
+		e = new Expression("a").with("a", "null");
+		assertEquals(null, e.eval());
+		
+		e = new Expression("a").with("a", (BigDecimal)null);
+		assertEquals(null, e.eval());
+		
+		String err = "";
+		try {
+			new Expression("a+1").with("a", "null").eval();
+		} catch (ArithmeticException ex) {
+			err = ex.getMessage();
+		}
+		assertEquals("First operand may not be null",err);
+	}
 }


### PR DESCRIPTION
With this change, NULL values are supported. If an operation does not support "null" as value, it will throw an exception.

NULL values can be used for functions like COALESCE() in SQL where the first non-null value is used.