### PR TITLE
Support null as value

### DIFF
--- a/src/com/udojava/evalex/Expression.java
+++ b/src/com/udojava/evalex/Expression.java
@@ -777,36 +777,42 @@ public class Expression {
 		addOperator(new Operator("+", 20, true) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.add(v2, mc);
 			}
 		});
 		addOperator(new Operator("-", 20, true) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.subtract(v2, mc);
 			}
 		});
 		addOperator(new Operator("*", 30, true) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.multiply(v2, mc);
 			}
 		});
 		addOperator(new Operator("/", 30, true) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.divide(v2, mc);
 			}
 		});
 		addOperator(new Operator("%", 30, true) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.remainder(v2, mc);
 			}
 		});
 		addOperator(new Operator("^", 40, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				/*- 
 				 * Thanks to Gene Marin:
 				 * http://stackoverflow.com/questions/3579779/how-to-do-a-fractional-power-on-bigdecimal-in-java
@@ -831,6 +837,7 @@ public class Expression {
 		addOperator(new Operator("&&", 4, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				boolean b1 = !v1.equals(BigDecimal.ZERO);
 				boolean b2 = !v2.equals(BigDecimal.ZERO);
 				return b1 && b2 ? BigDecimal.ONE : BigDecimal.ZERO;
@@ -840,6 +847,7 @@ public class Expression {
 		addOperator(new Operator("||", 2, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				boolean b1 = !v1.equals(BigDecimal.ZERO);
 				boolean b2 = !v2.equals(BigDecimal.ZERO);
 				return b1 || b2 ? BigDecimal.ONE : BigDecimal.ZERO;
@@ -849,6 +857,7 @@ public class Expression {
 		addOperator(new Operator(">", 10, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.compareTo(v2) == 1 ? BigDecimal.ONE : BigDecimal.ZERO;
 			}
 		});
@@ -856,6 +865,7 @@ public class Expression {
 		addOperator(new Operator(">=", 10, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.compareTo(v2) >= 0 ? BigDecimal.ONE : BigDecimal.ZERO;
 			}
 		});
@@ -863,6 +873,7 @@ public class Expression {
 		addOperator(new Operator("<", 10, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.compareTo(v2) == -1 ? BigDecimal.ONE
 						: BigDecimal.ZERO;
 			}
@@ -871,6 +882,7 @@ public class Expression {
 		addOperator(new Operator("<=", 10, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return v1.compareTo(v2) <= 0 ? BigDecimal.ONE : BigDecimal.ZERO;
 			}
 		});
@@ -878,6 +890,12 @@ public class Expression {
 		addOperator(new Operator("=", 7, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				if (v1 == v2) {
+					return BigDecimal.ONE;
+				}
+				if (v1 == null  || v2 == null) {
+					return BigDecimal.ZERO;
+				}
 				return v1.compareTo(v2) == 0 ? BigDecimal.ONE : BigDecimal.ZERO;
 			}
 		});
@@ -891,12 +909,19 @@ public class Expression {
 		addOperator(new Operator("!=", 7, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				if (v1 == v2) {
+					return BigDecimal.ZERO;
+				}
+				if (v1 == null  || v2 == null) {
+					return BigDecimal.ONE;
+				}
 				return v1.compareTo(v2) != 0 ? BigDecimal.ONE : BigDecimal.ZERO;
 			}
 		});
 		addOperator(new Operator("<>", 7, false) {
 			@Override
 			public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+				assertNotNull(v1, v2);
 				return operators.get("!=").eval(v1, v2);
 			}
 		});
@@ -904,6 +929,7 @@ public class Expression {
 		addFunction(new Function("NOT", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				boolean zero = parameters.get(0).compareTo(BigDecimal.ZERO) == 0;
 				return zero ? BigDecimal.ONE : BigDecimal.ZERO;
 			}
@@ -912,7 +938,9 @@ public class Expression {
 		addLazyFunction(new LazyFunction("IF", 3) {
 			@Override
 			public LazyNumber lazyEval(List<LazyNumber> lazyParams) {
-				boolean isTrue = !lazyParams.get(0).eval().equals(BigDecimal.ZERO);
+				BigDecimal result = lazyParams.get(0).eval();
+				assertNotNull(result);
+				boolean isTrue = !result.equals(BigDecimal.ZERO);
 				return isTrue ? lazyParams.get(1) : lazyParams.get(2);
 			}
 		});
@@ -927,6 +955,7 @@ public class Expression {
 		addFunction(new Function("SIN", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.sin(Math.toRadians(parameters.get(0)
 						.doubleValue()));
 				return new BigDecimal(d, mc);
@@ -935,6 +964,7 @@ public class Expression {
 		addFunction(new Function("COS", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.cos(Math.toRadians(parameters.get(0)
 						.doubleValue()));
 				return new BigDecimal(d, mc);
@@ -943,6 +973,7 @@ public class Expression {
 		addFunction(new Function("TAN", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.tan(Math.toRadians(parameters.get(0)
 						.doubleValue()));
 				return new BigDecimal(d, mc);
@@ -951,6 +982,7 @@ public class Expression {
 		addFunction(new Function("ASIN", 1) { // added by av
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.toDegrees(Math.asin(parameters.get(0)
 						.doubleValue()));
 				return new BigDecimal(d, mc);
@@ -959,6 +991,7 @@ public class Expression {
 		addFunction(new Function("ACOS", 1) { // added by av
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.toDegrees(Math.acos(parameters.get(0)
 						.doubleValue()));
 				return new BigDecimal(d, mc);
@@ -967,6 +1000,7 @@ public class Expression {
 		addFunction(new Function("ATAN", 1) { // added by av
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.toDegrees(Math.atan(parameters.get(0)
 						.doubleValue()));
 				return new BigDecimal(d, mc);
@@ -975,6 +1009,7 @@ public class Expression {
 		addFunction(new Function("SINH", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.sinh(parameters.get(0).doubleValue());
 				return new BigDecimal(d, mc);
 			}
@@ -982,6 +1017,7 @@ public class Expression {
 		addFunction(new Function("COSH", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.cosh(parameters.get(0).doubleValue());
 				return new BigDecimal(d, mc);
 			}
@@ -989,6 +1025,7 @@ public class Expression {
 		addFunction(new Function("TANH", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.tanh(parameters.get(0).doubleValue());
 				return new BigDecimal(d, mc);
 			}
@@ -996,6 +1033,7 @@ public class Expression {
 		addFunction(new Function("RAD", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.toRadians(parameters.get(0).doubleValue());
 				return new BigDecimal(d, mc);
 			}
@@ -1003,6 +1041,7 @@ public class Expression {
 		addFunction(new Function("DEG", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.toDegrees(parameters.get(0).doubleValue());
 				return new BigDecimal(d, mc);
 			}
@@ -1015,6 +1054,7 @@ public class Expression {
 				}
 				BigDecimal max = null;
 				for (BigDecimal parameter : parameters) {
+					assertNotNull(parameter);
 					if (max == null || parameter.compareTo(max) > 0) {
 						max = parameter;
 					}
@@ -1030,6 +1070,7 @@ public class Expression {
 				}
 				BigDecimal min = null;
 				for (BigDecimal parameter : parameters) {
+					assertNotNull(parameter);
 					if (min == null || parameter.compareTo(min) < 0) {
 						min = parameter;
 					}
@@ -1040,12 +1081,14 @@ public class Expression {
 		addFunction(new Function("ABS", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				return parameters.get(0).abs(mc);
 			}
 		});
 		addFunction(new Function("LOG", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.log(parameters.get(0).doubleValue());
 				return new BigDecimal(d, mc);
 			}
@@ -1053,6 +1096,7 @@ public class Expression {
 		addFunction(new Function("LOG10", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				double d = Math.log10(parameters.get(0).doubleValue());
 				return new BigDecimal(d, mc);
 			}
@@ -1060,6 +1104,7 @@ public class Expression {
 		addFunction(new Function("ROUND", 2) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0), parameters.get(1));
 				BigDecimal toRound = parameters.get(0);
 				int precision = parameters.get(1).intValue();
 				return toRound.setScale(precision, mc.getRoundingMode());
@@ -1068,6 +1113,7 @@ public class Expression {
 		addFunction(new Function("FLOOR", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				BigDecimal toRound = parameters.get(0);
 				return toRound.setScale(0, RoundingMode.FLOOR);
 			}
@@ -1075,6 +1121,7 @@ public class Expression {
 		addFunction(new Function("CEILING", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				BigDecimal toRound = parameters.get(0);
 				return toRound.setScale(0, RoundingMode.CEILING);
 			}
@@ -1082,6 +1129,7 @@ public class Expression {
 		addFunction(new Function("SQRT", 1) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
+				assertNotNull(parameters.get(0));
 				/*
 				 * From The Java Programmers Guide To numerical Computing
 				 * (Ronald Mak, 2003)
@@ -1114,9 +1162,25 @@ public class Expression {
 
 		variables.put("e", e);
 		variables.put("PI", PI);
+		variables.put("NULL", null);
 		variables.put("TRUE", BigDecimal.ONE);
 		variables.put("FALSE", BigDecimal.ZERO);
 
+	}
+	
+	private void assertNotNull(BigDecimal v1) {
+		if (v1 == null) {
+			throw new ArithmeticException("Operand may not be null");
+		}
+	}
+	
+	private void assertNotNull(BigDecimal v1, BigDecimal v2) {
+		if (v1 == null) {
+			throw new ArithmeticException("First operand may not be null");
+		}
+		if (v2 == null) {
+			throw new ArithmeticException("Second operand may not be null");
+		}		
 	}
 
 	/**
@@ -1276,7 +1340,8 @@ public class Expression {
 
 					stack.push(new LazyNumber() {
 						public BigDecimal eval() {
-							return variables.get(token.surface).round(mc);
+							BigDecimal value = variables.get(token.surface);
+							return value == null ? null : value.round(mc);
 						}
 					});
 					break;
@@ -1301,12 +1366,17 @@ public class Expression {
 				case LITERAL:
 					stack.push(new LazyNumber() {
 						public BigDecimal eval() {
+							if (token.surface.equalsIgnoreCase("NULL")) {
+								return null;
+							}
+
 							return new BigDecimal(token.surface, mc);
 						}
 					});
 			}
 		}
-		return stack.pop().eval().stripTrailingZeros();
+		BigDecimal result = stack.pop().eval();
+		return result == null ? null : result.stripTrailingZeros();
 	}
 
 	/**
@@ -1422,6 +1492,9 @@ public class Expression {
 	public Expression setVariable(String variable, String value) {
 		if (isNumber(value))
 			variables.put(variable, new BigDecimal(value));
+		else if (value.equalsIgnoreCase("null")) {
+			variables.put(variable, null);
+		}
 		else {
 			expression = expression.replaceAll("(?i)\\b" + variable + "\\b", "("
 					+ value + ")");

--- a/tests/com/udojava/evalex/TestEval.java
+++ b/tests/com/udojava/evalex/TestEval.java
@@ -392,4 +392,47 @@ public class TestEval {
 
 		assertEquals("Unknown operator '|*|' at position 3", err);
 	}
+
+	@Test
+	public void testNull() {
+		Expression e = null;
+		e = new Expression("null");
+		assertEquals(null, e.eval());
+	}
+	
+	@Test
+	public void testCalculationWithNull() {
+		String err = "";
+		try {
+			new Expression("null+1").eval();
+		} catch (ArithmeticException e) {
+			err = e.getMessage();
+		}
+		assertEquals("First operand may not be null",err);
+		
+		err = "";
+		try {
+			new Expression("1 + NULL").eval();
+		} catch (ArithmeticException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Second operand may not be null",err);
+		
+		err = "";
+		try {
+			new Expression("round(Null, 1)").eval();
+		} catch (ArithmeticException e) {
+			err = e.getMessage();
+		}
+		assertEquals("First operand may not be null",err);
+
+		err = "";
+		try {
+			new Expression("round(1, NulL)").eval();
+		} catch (ArithmeticException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Second operand may not be null",err);
+	}
+
 }

--- a/tests/com/udojava/evalex/TestLazyIf.java
+++ b/tests/com/udojava/evalex/TestLazyIf.java
@@ -3,6 +3,8 @@ package com.udojava.evalex;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 import java.math.BigDecimal;
 
 /**
@@ -18,4 +20,16 @@ public class TestLazyIf {
         Assert.assertEquals(expression.eval(),new BigDecimal(0));
 
     }
+    
+    @Test
+    public void testLazyIfWithNull() {
+		String err = "";
+		try {
+        	new Expression("if(a,0,12/a)").setVariable("a", "null").eval();
+		} catch (ArithmeticException e) {
+			err = e.getMessage();
+		}
+		assertEquals("Operand may not be null",err);
+    }
+
 }

--- a/tests/com/udojava/evalex/TestVariables.java
+++ b/tests/com/udojava/evalex/TestVariables.java
@@ -88,4 +88,22 @@ public class TestVariables {
 	public void failsIfVariableDoesNotExist() throws Exception {
 		new Expression("3*unknown").eval();
 	}
+	
+	@Test
+	public void testNullVariable() {
+		Expression e = null;
+		e = new Expression("a").with("a", "null");
+		assertEquals(null, e.eval());
+		
+		e = new Expression("a").with("a", (BigDecimal)null);
+		assertEquals(null, e.eval());
+		
+		String err = "";
+		try {
+			new Expression("a+1").with("a", "null").eval();
+		} catch (ArithmeticException ex) {
+			err = ex.getMessage();
+		}
+		assertEquals("First operand may not be null",err);
+	}
 }


### PR DESCRIPTION
With this change, NULL values are supported. If an operation does not support "null" as value, it will throw an exception.

NULL values can be used for functions like COALESCE() in SQL where the first non-null value is used.

This is a rebase of: https://github.com/uklimaschewski/EvalEx/pull/102