### PR TITLE
Make LazyNumber Public

### DIFF
--- a/src/com/udojava/evalex/Expression.java
+++ b/src/com/udojava/evalex/Expression.java
@@ -461,7 +461,7 @@ public class Expression {
 	/**
 	 * LazyNumber interface created for lazily evaluated functions
 	 */
-	interface LazyNumber {
+	public interface LazyNumber {
 		BigDecimal eval();
 		String getString();
 	}


### PR DESCRIPTION
This is a follow up code update for #106 

I just realised that the LazyNumber Interface is not public, thus not allowing LazyNumber instantiation outside the package. This stops you from adding LazyFunction right before you want to evaluate an expression.

With this change, it allows you to add LazyFunctions right before the expression evaluation as well as create LazyNumber Instances which can be reusable in any additional LazyFunction addition to the expression object.

Example:
```java
Expression expression = new Expression(formula);
LazyNumber ZERO = new LazyNumber() {
    
    public BigDecimal eval() {
        return BigDecimal.ZERO;
    }
    
    public String getString() {
        return "0";
    }
};

LazyNumber ONE = new LazyNumber() {
    
    public BigDecimal eval() {
        return BigDecimal.ONE;
    }
    
    public String getString() {
        return "1";
    }
};

expression.addLazyFunction(expression.new LazyFunction("STREQ", 2) {
    
    @Override
    public LazyNumber lazyEval(List<LazyNumber> lazyParams) {
        if (lazyParams.get(0).getString().equals(lazyParams.get(1).getString())) {
            return ONE;
        }
        return ZERO;
    }
});

expression.addLazyFunction(expression.new LazyFunction("STRNOTEQ", 2) {
    
    @Override
    public LazyNumber lazyEval(List<LazyNumber> lazyParams) {
        if (lazyParams.get(0).getString().equals(lazyParams.get(1).getString())) {
            return ZERO;
        }
        return ONE;
    }
});
```
