### PR TITLE
#144 Extracted LazyFunction, Function and Operator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ For example, add an operator `x >> n`, that moves the decimal point of _x_ _n_ d
 ````java
 Expression e = new Expression("2.1234 >> 2");
 
-e.addOperator(e.new Operator(">>", 30, true) {
+e.addOperator(new AbstractOperator(">>", 30, true) {
     @Override
     public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
         return v1.movePointRight(v2.toBigInteger().intValue());
@@ -180,7 +180,7 @@ For example, add a function `average(a,b,c)`, that will calculate the average va
 ````java
 Expression e = new Expression("2 * average(12,4,8)");
 
-e.addFunction(e.new Function("average", -1) {
+e.addFunction(new AbstractFunction("average", -1) {
     @Override
     public BigDecimal eval(List<BigDecimal> parameters) {
 				if (parameters.size() == 0) {
@@ -207,7 +207,7 @@ For example, add a function `STREQ("string1","string2")`, that will compare whet
 
 ````java
 Expression e = new Expression("STREQ(\"test\", \"test2\")");
-e.addLazyFunction(e.new LazyFunction("STREQ", 2) {
+e.addLazyFunction(new AbstractLazyFunction("STREQ", 2) {
     private LazyNumber ZERO = new LazyNumber() {
         public BigDecimal eval() {
             return BigDecimal.ZERO;
@@ -245,7 +245,7 @@ The software was created and tested using Java 1.6.0.
   
 ### Author and License
 
-Copyright 2012-2017 by Udo Klimaschewski
+Copyright 2012-2018 by Udo Klimaschewski
 
 http://about.me/udo.klimaschewski
 

--- a/src/main/java/com/udojava/evalex/AbstractFunction.java
+++ b/src/main/java/com/udojava/evalex/AbstractFunction.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Udo Klimaschewski
+ * 
+ * http://UdoJava.com/
+ * http://about.me/udo.klimaschewski
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+package com.udojava.evalex;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.udojava.evalex.Expression.LazyNumber;
+
+/**
+ * Abstract implementation of a direct function.<br>
+ * <br>
+ * This abstract implementation does implement lazyEval so that it returns
+ * the result of eval.
+ */
+public abstract class AbstractFunction extends AbstractLazyFunction implements Function {
+
+	/**
+	 * Creates a new function with given name and parameter count.
+	 *
+	 * @param name
+	 *            The name of the function.
+	 * @param numParams
+	 *            The number of parameters for this function.
+	 *            <code>-1</code> denotes a variable number of parameters.
+	 */
+	protected AbstractFunction(String name, int numParams) {
+		super(name, numParams);
+	}
+
+	/**
+	 * Creates a new function with given name and parameter count.
+	 *
+	 * @param name
+	 *            The name of the function.
+	 * @param numParams
+	 *            The number of parameters for this function.
+	 *            <code>-1</code> denotes a variable number of parameters.
+	 * @param booleanFunction
+	 *            Whether this function is a boolean function.
+	 */
+	protected AbstractFunction(String name, int numParams, boolean booleanFunction) {
+		super(name, numParams, booleanFunction);
+	}
+
+	public LazyNumber lazyEval(final List<LazyNumber> lazyParams) {
+		return new LazyNumber() {
+
+			private List<BigDecimal> params;
+
+			public BigDecimal eval() {
+				return AbstractFunction.this.eval(getParams());
+			}
+
+			public String getString() {
+				return String.valueOf(AbstractFunction.this.eval(getParams()));
+			}
+
+			private List<BigDecimal> getParams() {
+				if (params == null) {
+					params = new ArrayList<BigDecimal>();
+					for (LazyNumber lazyParam : lazyParams) {
+						params.add(lazyParam.eval());
+					}
+				}
+				return params;
+			}
+		};
+	}
+}

--- a/src/main/java/com/udojava/evalex/AbstractLazyFunction.java
+++ b/src/main/java/com/udojava/evalex/AbstractLazyFunction.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 Udo Klimaschewski
+ * 
+ * http://UdoJava.com/
+ * http://about.me/udo.klimaschewski
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+package com.udojava.evalex;
+
+import java.util.Locale;
+
+/**
+ * Abstract implementation of a lazy function which implements all necessary
+ * methods with the exception of the main logic.
+ */
+public abstract class AbstractLazyFunction implements LazyFunction {
+	/**
+	 * Name of this function.
+	 */
+	protected String name;
+	/**
+	 * Number of parameters expected for this function. <code>-1</code>
+	 * denotes a variable number of parameters.
+	 */
+	protected int numParams;
+
+	/**
+	 * Whether this function is a boolean function.
+	 */
+	protected boolean booleanFunction;
+
+	/**
+	 * Creates a new function with given name and parameter count.
+	 *
+	 * @param name
+	 *            The name of the function.
+	 * @param numParams
+	 *            The number of parameters for this function.
+	 *            <code>-1</code> denotes a variable number of parameters.
+	 * @param booleanFunction
+	 *            Whether this function is a boolean function.
+	 */
+	protected AbstractLazyFunction(String name, int numParams, boolean booleanFunction) {
+		this.name = name.toUpperCase(Locale.ROOT);
+		this.numParams = numParams;
+		this.booleanFunction = booleanFunction;
+	}
+
+	/**
+	 * Creates a new function with given name and parameter count.
+	 *
+	 * @param name
+	 *            The name of the function.
+	 * @param numParams
+	 *            The number of parameters for this function.
+	 *            <code>-1</code> denotes a variable number of parameters.
+	 */
+	protected AbstractLazyFunction(String name, int numParams) {
+		this(name, numParams, false);
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public int getNumParams() {
+		return numParams;
+	}
+
+	public boolean numParamsVaries() {
+		return numParams < 0;
+	}
+
+	public boolean isBooleanFunction() {
+		return booleanFunction;
+	}
+}

--- a/src/main/java/com/udojava/evalex/AbstractOperator.java
+++ b/src/main/java/com/udojava/evalex/AbstractOperator.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 Udo Klimaschewski
+ * 
+ * http://UdoJava.com/
+ * http://about.me/udo.klimaschewski
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+package com.udojava.evalex;
+
+/**
+ * Abstract implementation of an operator.
+ */
+public abstract class AbstractOperator implements Operator {
+	/**
+	 * This operators name (pattern).
+	 */
+	protected String oper;
+	/**
+	 * Operators precedence.
+	 */
+	protected int precedence;
+	/**
+	 * Operator is left associative.
+	 */
+	protected boolean leftAssoc;
+	/**
+	 * Whether this operator is boolean or not.
+	 */
+	protected boolean booleanOperator = false;
+
+	/**
+	 * Creates a new operator.
+	 * 
+	 * @param oper
+	 *            The operator name (pattern).
+	 * @param precedence
+	 *            The operators precedence.
+	 * @param leftAssoc
+	 *            <code>true</code> if the operator is left associative,
+	 *            else <code>false</code>.
+	 * @param booleanOperator
+	 *            Whether this operator is boolean.
+	 */
+	protected AbstractOperator(String oper, int precedence, boolean leftAssoc, boolean booleanOperator) {
+		this.oper = oper;
+		this.precedence = precedence;
+		this.leftAssoc = leftAssoc;
+		this.booleanOperator = booleanOperator;
+	}
+
+	/**
+	 * Creates a new operator.
+	 * 
+	 * @param oper
+	 *            The operator name (pattern).
+	 * @param precedence
+	 *            The operators precedence.
+	 * @param leftAssoc
+	 *            <code>true</code> if the operator is left associative,
+	 *            else <code>false</code>.
+	 */
+	protected AbstractOperator(String oper, int precedence, boolean leftAssoc) {
+		this.oper = oper;
+		this.precedence = precedence;
+		this.leftAssoc = leftAssoc;
+	}
+
+	public String getOper() {
+		return oper;
+	}
+
+	public int getPrecedence() {
+		return precedence;
+	}
+
+	public boolean isLeftAssoc() {
+		return leftAssoc;
+	}
+
+	public boolean isBooleanOperator() {
+		return booleanOperator;
+	}
+}

--- a/src/main/java/com/udojava/evalex/AbstractUnaryOperator.java
+++ b/src/main/java/com/udojava/evalex/AbstractUnaryOperator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Udo Klimaschewski
+ * 
+ * http://UdoJava.com/
+ * http://about.me/udo.klimaschewski
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+package com.udojava.evalex;
+
+import java.math.BigDecimal;
+
+import com.udojava.evalex.Expression.ExpressionException;
+
+/**
+ * Abstract implementation of an unary operator.<br>
+ * <br>
+ * This abstract implementation implements eval so that it forwards its first
+ * parameter to evalUnary.
+ */
+public abstract class AbstractUnaryOperator extends AbstractOperator {
+
+	/**
+	 * Creates a new operator.
+	 * 
+	 * @param oper
+	 *            The operator name (pattern).
+	 * @param precedence
+	 *            The operators precedence.
+	 * @param leftAssoc
+	 *            <code>true</code> if the operator is left associative,
+	 *            else <code>false</code>.
+	 * @param booleanOperator
+	 *            Whether this operator is boolean.
+	 */
+	protected AbstractUnaryOperator(String oper, int precedence, boolean leftAssoc) {
+		super(oper, precedence, leftAssoc);
+	}
+
+	public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+		if (v2 != null) {
+			throw new ExpressionException("Did not expect a second parameter for unary operator");
+		}
+		return evalUnary(v1);
+	}
+
+	/**
+	 * Implementation of this unary operator.
+	 * 
+	 * @param v1
+	 *            The parameter.
+	 * @return The result of the operation.
+	 */
+	public abstract BigDecimal evalUnary(BigDecimal v1);
+}

--- a/src/main/java/com/udojava/evalex/Function.java
+++ b/src/main/java/com/udojava/evalex/Function.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Udo Klimaschewski
+ * 
+ * http://UdoJava.com/
+ * http://about.me/udo.klimaschewski
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+package com.udojava.evalex;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Base interface which is required for all directly evaluated functions.
+ */
+public interface Function extends LazyFunction {
+
+	/**
+	 * Implementation for this function.
+	 *
+	 * @param parameters
+	 *            Parameters will be passed by the expression evaluator as a
+	 *            {@link List} of {@link BigDecimal} values.
+	 * @return The function must return a new {@link BigDecimal} value as a
+	 *         computing result.
+	 */
+	public abstract BigDecimal eval(List<BigDecimal> parameters);
+}

--- a/src/main/java/com/udojava/evalex/LazyFunction.java
+++ b/src/main/java/com/udojava/evalex/LazyFunction.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Udo Klimaschewski
+ * 
+ * http://UdoJava.com/
+ * http://about.me/udo.klimaschewski
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+package com.udojava.evalex;
+
+import java.util.List;
+
+import com.udojava.evalex.Expression.LazyNumber;
+
+/**
+ * Base interface which is required for lazily evaluated functions. A function
+ * is defined by a name, a number of parameters it accepts and of course
+ * the logic for evaluating the result.
+ */
+public interface LazyFunction {
+
+	/**
+	 * Gets the name of this function.<br>
+	 * <br>
+	 * The name is use to invoke this function in the expression.
+	 * 
+	 * @return The name of this function.
+	 */
+	public abstract String getName();
+
+	/**
+	 * Gets the number of parameters this function accepts.<br>
+	 * <br>
+	 * A value of <code>-1</code> denotes that this function accepts a variable
+	 * number of parameters.
+	 * 
+	 * @return The number of parameters this function accepts.
+	 */
+	public abstract int getNumParams();
+
+	/**
+	 * Gets whether the number of accepted parameters varies.<br>
+	 * <br>
+	 * That means that the function does accept an undefined amount of
+	 * parameters.
+	 * 
+	 * @return <code>true</code> if the number of accepted parameters varies.
+	 */
+	public abstract boolean numParamsVaries();
+
+	/**
+	 * Gets whether this function evaluates to a boolean expression.
+	 * 
+	 * @return <code>true</code> if this function evaluates to a boolean
+	 *         expression.
+	 */
+	public abstract boolean isBooleanFunction();
+
+	/**
+	 * Lazily evaluate this function.
+	 * 
+	 * @param lazyParams
+	 *            The accepted parameters.
+	 * @return The lazy result of this function.
+	 */
+	public abstract LazyNumber lazyEval(List<LazyNumber> lazyParams);
+}

--- a/src/main/java/com/udojava/evalex/Operator.java
+++ b/src/main/java/com/udojava/evalex/Operator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Udo Klimaschewski
+ * 
+ * http://UdoJava.com/
+ * http://about.me/udo.klimaschewski
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+package com.udojava.evalex;
+
+import java.math.BigDecimal;
+
+/**
+ * Base interface which is required for all operators.
+ */
+public interface Operator {
+
+	/**
+	 * Gets the String that is used to denote the operator in the expression.
+	 * 
+	 * @return The String that is used to denote the operator in the expression.
+	 */
+	public abstract String getOper();
+
+	/**
+	 * Gets the precedence value of this operator.
+	 * 
+	 * @return the precedence value of this operator.
+	 */
+	public abstract int getPrecedence();
+
+	/**
+	 * Gets whether this operator is left associative (<code>true</code>) or if
+	 * this operator is right associative (<code>false</code>).
+	 * 
+	 * @return <code>true</code> if this operator is left associative.
+	 */
+	public abstract boolean isLeftAssoc();
+	
+	/**
+	 * Gets whether this operator evaluates to a boolean expression.
+	 * @return <code>true</code> if this operator evaluates to a boolean
+	 *         expression.
+	 */
+	public abstract boolean isBooleanOperator();
+
+	/**
+	 * Implementation for this operator.
+	 * 
+	 * @param v1
+	 *            Operand 1.
+	 * @param v2
+	 *            Operand 2.
+	 * @return The result of the operation.
+	 */
+	public abstract BigDecimal eval(BigDecimal v1, BigDecimal v2);
+}

--- a/src/test/java/com/udojava/evalex/TestCustoms.java
+++ b/src/test/java/com/udojava/evalex/TestCustoms.java
@@ -28,6 +28,20 @@ public class TestCustoms {
 	@Test
 	public void testCustomFunction() {
 		Expression e = new Expression("2 * average(12,4,8)");
+		e.addFunction(new AbstractFunction("average", 3) {
+			@Override
+			public BigDecimal eval(List<BigDecimal> parameters) {
+				BigDecimal sum = parameters.get(0).add(parameters.get(1)).add(parameters.get(2));
+				return sum.divide(new BigDecimal(3));
+			}
+		});
+		
+		assertEquals("16", e.eval().toPlainString());
+	}
+	
+	@Test
+	public void testCustomFunctionInstanceClass() {
+		Expression e = new Expression("2 * average(12,4,8)");
 		e.addFunction(e.new Function("average", 3) {
 			@Override
 			public BigDecimal eval(List<BigDecimal> parameters) {
@@ -41,6 +55,23 @@ public class TestCustoms {
 	
 	@Test
 	public void testCustomFunctionVariableParameters() {
+		Expression e = new Expression("2 * average(12,4,8,2,9)");
+		e.addFunction(new AbstractFunction("average", -1) {
+			@Override
+			public BigDecimal eval(List<BigDecimal> parameters) {
+				BigDecimal sum = new BigDecimal(0);
+				for (BigDecimal parameter : parameters) {
+					sum = sum.add(parameter);
+				}
+				return sum.divide(new BigDecimal(parameters.size()));
+			}
+		});
+		
+		assertEquals("14", e.eval().toPlainString());
+	}
+	
+	@Test
+	public void testCustomFunctionVariableParametersInstanceClass() {
 		Expression e = new Expression("2 * average(12,4,8,2,9)");
 		e.addFunction(e.new Function("average", -1) {
 			@Override
@@ -58,6 +89,42 @@ public class TestCustoms {
 	
 	@Test
 	public void testCustomFunctionStringParameters() {
+        Expression e = new Expression("STREQ(\"test\", \"test2\")");
+        e.addLazyFunction(e.new LazyFunction("STREQ", 2) {
+            private LazyNumber ZERO = new LazyNumber() {
+                public BigDecimal eval() {
+                    return BigDecimal.ZERO;
+                }
+                
+                public String getString() {
+                    return "0";
+                }
+             };
+           
+            private LazyNumber ONE = new LazyNumber() {
+                public BigDecimal eval() {
+                    return BigDecimal.ONE;
+                }
+                 
+                public String getString() {
+                    return null;
+                }
+            };
+          
+            @Override
+            public LazyNumber lazyEval(List<LazyNumber> lazyParams) {
+                if (lazyParams.get(0).getString().equals(lazyParams.get(1).getString())) {
+                    return ZERO;
+                }
+                return ONE;
+            }
+        });
+       
+        assertEquals("1", e.eval().toPlainString());
+	}
+	
+	@Test
+	public void testCustomFunctionStringParametersInstanceClass() {
         Expression e = new Expression("STREQ(\"test\", \"test2\")");
         e.addLazyFunction(e.new LazyFunction("STREQ", 2) {
             private LazyNumber ZERO = new LazyNumber() {


### PR DESCRIPTION
Description
===========

This changeset adds "external" interfaces and abstract implementations for functions and operators, previously functions and operators had to be inner classes of `Expression`.


Changes
-------

New interfaces:

 * `LazyFunction`
 * `Function`
 * `Operator`

New abstract implementations:

 * `AbstractLazyFunction`
 * `AbstractFunction`
 * `AbstractOperator`
 * `AbstractUnaryOperator`

The README and the documentation have been updated to use the new classes.


Backwards compatibility
-----------------------

The inner classes in `Expression` are now extending these new interfaces and abstract implementations.

Source compatibility is preserved with the exception that the `setBooleanFunction` function was removed. I've done that  because it seemed oddly misplaced, given that `LazyFunction` implementations were immutable with the sole exception of that property.

Binary compatibility is broken because the following functions have changed:

 * `Expression.addOperator(Expression.Operator)` changed to `Expression.addOperator(com.udojava.evalex.Operator)`
 * `Expression.addLazyFunction(Expression.LazyFunction)` changed to `Expression.addLazyFunction(com.udojava.evalex.LazyFunction)`
 * `Expression.addFunction(Expression.Function)` changed to `Expression.addFunction(com.udojava.evalex.Function)`

Adding an overload for these functions which accept the inner classes would be possible, but would pollute the API and add ambiguousness which might lead to compilation errors.


Copyright
---------

Because the work was mostly refactoring and moving around of already existing code, the copyright header of the new files lists Udo Klimaschewski as author, that is intentional.
