### PR TITLE
Fix parameters used in inner classes without final declaration

### DIFF
--- a/src/main/java/com/udojava/evalex/AbstractOperator.java
+++ b/src/main/java/com/udojava/evalex/AbstractOperator.java
@@ -66,7 +66,7 @@ public abstract class AbstractOperator extends AbstractLazyOperator implements O
 		super(oper, precedence, leftAssoc);
 	}
 
-	public LazyNumber eval(LazyNumber v1, LazyNumber v2) {
+	public LazyNumber eval(final LazyNumber v1, final LazyNumber v2) {
 		return new LazyNumber() {
 			public BigDecimal eval() {
 				return AbstractOperator.this.eval(v1.eval(), v2.eval());

--- a/src/main/java/com/udojava/evalex/AbstractUnaryOperator.java
+++ b/src/main/java/com/udojava/evalex/AbstractUnaryOperator.java
@@ -56,7 +56,7 @@ public abstract class AbstractUnaryOperator extends AbstractOperator {
 		super(oper, precedence, leftAssoc);
 	}
 
-	public LazyNumber eval(LazyNumber v1, LazyNumber v2) {
+	public LazyNumber eval(final LazyNumber v1, final LazyNumber v2) {
 		if (v2 != null) {
 			throw new ExpressionException("Did not expect a second parameter for unary operator");
 		}


### PR DESCRIPTION
The parameters used by the inner class in the method need to be declared as final, otherwise the project will be built with errors.