### PR TITLE
circularcheck

### DIFF
--- a/src/main/java/com/udojava/evalex/Expression.java
+++ b/src/main/java/com/udojava/evalex/Expression.java
@@ -1852,12 +1852,14 @@ public class Expression {
 		final Set<String> varWithValue = new HashSet<String>();
 		int lastvarWithValueCnt = varWithValue.size();
         String lastCheckVar = "";
+        final Set<String> alreadyCheckSet = new HashSet<String>();
         final Set<String> lastCheckSet = new HashSet<String>();
 		while (!checks.isEmpty()) {
 			String check = checks.peek();
 			if (mark.equals(check)) {
+                lastCheckSet.removeAll(varWithValue);
 				if (varWithValue.size() < lastvarWithValueCnt
-                    || (varWithValue.size() == lastvarWithValueCnt && lastCheckSet.contains(lastCheckVar))) {
+                    || (varWithValue.size() == lastvarWithValueCnt && alreadyCheckSet.containsAll(lastCheckSet))) {
 					throw new ExpressionException("circular reference var : " + lastCheckVar);
 				} else {
 					lastvarWithValueCnt = varWithValue.size();
@@ -1871,7 +1873,7 @@ public class Expression {
 				}
 				LazyNumber innerVariable = variables.get(check);
 				String innerExp = innerVariable.getString();
-				if (isNumber(innerExp)) {
+				if (varWithValue.contains(check) || isNumber(innerExp)) {
 					varWithValue.add(check);
 				} else {
 					Expression exp = createEmbeddedExpression(innerExp);
@@ -1881,6 +1883,7 @@ public class Expression {
 						varWithValue.add(check);
 					} else {
                         lastCheckVar = check;
+                        alreadyCheckSet.add(check);
                         lastCheckSet.addAll(tocheck);
 						checks.addAll(tocheck);
 					}

--- a/src/main/java/com/udojava/evalex/Expression.java
+++ b/src/main/java/com/udojava/evalex/Expression.java
@@ -1858,7 +1858,9 @@ public class Expression {
 					throw new ExpressionException("circular reference var");
 				} else {
 					lastvarWithValueCnt = varWithValue.size();
-					checks.add(mark);
+					if (checks.size() > 1) {
+						checks.add(mark);
+					}
 				}
 			} else {
 				if (!variables.containsKey(check)) {

--- a/src/main/java/com/udojava/evalex/Expression.java
+++ b/src/main/java/com/udojava/evalex/Expression.java
@@ -1851,16 +1851,15 @@ public class Expression {
 		checks.offer(mark);
 		final Set<String> varWithValue = new HashSet<String>();
 		int lastvarWithValueCnt = varWithValue.size();
-        String lastCheck = "";
-        final Set<String> lasttodocheck = new HashSet<String>();
+        String lastCheckVar = "";
+        final Set<String> lastCheckSet = new HashSet<String>();
 		while (!checks.isEmpty()) {
 			String check = checks.peek();
 			if (mark.equals(check)) {
-				if (varWithValue.size() < lastvarWithValueCnt ) {
-					throw new ExpressionException("circular reference var");
-				} else if (varWithValue.size() == lastvarWithValueCnt && lasttodocheck.contains(lastCheck)){
-                    throw new ExpressionException("circular reference var");
-                } else {
+				if (varWithValue.size() < lastvarWithValueCnt
+                    || (varWithValue.size() == lastvarWithValueCnt && lastCheckSet.contains(lastCheckVar))) {
+					throw new ExpressionException("circular reference var : " + lastCheckVar);
+				} else {
 					lastvarWithValueCnt = varWithValue.size();
 					if (checks.size() > 1) {
 						checks.add(mark);
@@ -1870,7 +1869,6 @@ public class Expression {
 				if (!variables.containsKey(check)) {
 					throw new ExpressionException("unknown var : " + check);
 				}
-                lastCheck = check;
 				LazyNumber innerVariable = variables.get(check);
 				String innerExp = innerVariable.getString();
 				if (isNumber(innerExp)) {
@@ -1882,7 +1880,8 @@ public class Expression {
 					if (tocheck.isEmpty()) {
 						varWithValue.add(check);
 					} else {
-                        lasttodocheck.addAll(tocheck);
+                        lastCheckVar = check;
+                        lastCheckSet.addAll(tocheck);
 						checks.addAll(tocheck);
 					}
 				}

--- a/src/main/java/com/udojava/evalex/Expression.java
+++ b/src/main/java/com/udojava/evalex/Expression.java
@@ -1851,12 +1851,16 @@ public class Expression {
 		checks.offer(mark);
 		final Set<String> varWithValue = new HashSet<String>();
 		int lastvarWithValueCnt = varWithValue.size();
+        String lastCheck = "";
+        final Set<String> lasttodocheck = new HashSet<String>();
 		while (!checks.isEmpty()) {
 			String check = checks.peek();
 			if (mark.equals(check)) {
-				if (varWithValue.size() <= lastvarWithValueCnt) {
+				if (varWithValue.size() < lastvarWithValueCnt ) {
 					throw new ExpressionException("circular reference var");
-				} else {
+				} else if (varWithValue.size() == lastvarWithValueCnt && lasttodocheck.contains(lastCheck)){
+                    throw new ExpressionException("circular reference var");
+                } else {
 					lastvarWithValueCnt = varWithValue.size();
 					if (checks.size() > 1) {
 						checks.add(mark);
@@ -1866,6 +1870,7 @@ public class Expression {
 				if (!variables.containsKey(check)) {
 					throw new ExpressionException("unknown var : " + check);
 				}
+                lastCheck = check;
 				LazyNumber innerVariable = variables.get(check);
 				String innerExp = innerVariable.getString();
 				if (isNumber(innerExp)) {
@@ -1877,6 +1882,7 @@ public class Expression {
 					if (tocheck.isEmpty()) {
 						varWithValue.add(check);
 					} else {
+                        lasttodocheck.addAll(tocheck);
 						checks.addAll(tocheck);
 					}
 				}

--- a/src/main/java/com/udojava/evalex/Expression.java
+++ b/src/main/java/com/udojava/evalex/Expression.java
@@ -1846,21 +1846,21 @@ public class Expression {
 	 */
 	public void varDefValidation() {
 		final Set<String> varWithValue = new HashSet<String>();
-		final Set<String> circularRef = new HashSet<String>();
 		Queue<String> checks = new LinkedList<String>(new HashSet<String>(getUsedVariables()));
+		Queue<String> circular = new LinkedList<String>();
 		while (!checks.isEmpty()) {
 			String check = checks.peek();
 			if (!variables.containsKey(check)) {
 				throw new ExpressionException("unknown var : " + check);
 			}
-			if (circularRef.contains(check) && !varWithValue.contains(check)) {
+			if (check.equals(circular.peek())) {
 				throw new ExpressionException("circular reference var : " + check);
-			} else {
-				circularRef.add(check);
 			}
 			LazyNumber innerVariable = variables.get(check);
 			String innerExp = innerVariable.getString();
-			if (!isNumber(innerExp)) {
+			if (isNumber(innerExp)) {
+				varWithValue.add(check);
+			} else {
 				Expression exp = createEmbeddedExpression(innerExp);
 				Set<String> tocheck = new HashSet<String>(exp.getUsedVariables());
 				tocheck.removeAll(varWithValue);
@@ -1869,12 +1869,12 @@ public class Expression {
 				} else {
 					checks.addAll(tocheck);
 				}
-			} else {
-				varWithValue.add(check);
+			}
+			if (!varWithValue.contains(check)) {
+				circular.add(check);
 			}
 			checks.poll();
 		}
-		return;
 	}
 
 	/**

--- a/src/test/java/com/udojava/evalex/TestNested.java
+++ b/src/test/java/com/udojava/evalex/TestNested.java
@@ -84,13 +84,13 @@ public class TestNested {
         }
 
         try {
-			String a = "a + b + c + d + e + f";
+			String a = "a + b + c + d + f + g";
 			Expression e = new Expression(a);
 			e.with("a", "b");
 			e.with("b", "c");
 			e.with("c", "d");
-			e.with("d", "e");
-			e.with("e", "f");
+			e.with("d", "f");
+			e.with("f", "g");
 			e.with("f", "1");
 			assertEquals("6", e.eval().toString());
         } catch (ExpressionException e) {
@@ -111,7 +111,7 @@ public class TestNested {
         }
         assertEquals("circular reference var : f", err);
 
-		try {
+        try {
 			String a = "a + b + c + d + f + g";
 			Expression e = new Expression(a);
 			e.with("a", "b");
@@ -121,35 +121,46 @@ public class TestNested {
 			e.with("f", "g");
 			e.with("g", "a");
 			e.eval();
-		} catch (ExpressionException e) {
+        } catch (ExpressionException e) {
 			err = e.getMessage();
-		}
-		assertEquals("circular reference var : g", err);
+        }
+        assertEquals("circular reference var : g", err);
 
-		try {
+        try {
 			String a = "a + b";
 			Expression e = new Expression(a);
 			e.with("a", "a + b");
 			e.with("b", "0");
 			e.eval();
-		} catch (ExpressionException e) {
+        } catch (ExpressionException e) {
 			err = e.getMessage();
-		}
-		assertEquals("circular reference var : a", err);
+        }
+        assertEquals("circular reference var : a", err);
 
-		try {
+        try {
 			String a = "a";
 			Expression e = new Expression(a);
 			e.with("a", "b");
 			e.with("b", "c");
 			e.with("c", "d");
-			e.with("d", "e");
-			e.with("e", "f");
-			e.with("f", "1");
+			e.with("d", "f");
+			e.with("f", "g");
+			e.with("g", "1");
 			assertEquals("1", e.eval().toString());
-		} catch (ExpressionException e) {
+        } catch (ExpressionException e) {
 			err = e.getMessage();
-		}
+        }
+
+        try {
+            String a = "math3";
+            Expression e = new Expression(a);
+            e.with("math3", "math2 + 100");
+            e.with("math2", "math1 + 100");
+            e.with("math1", "1");
+            assertEquals("201", e.eval().toString());
+        } catch (ExpressionException e) {
+            err = e.getMessage();
+        }
 
 	}
 

--- a/src/test/java/com/udojava/evalex/TestNested.java
+++ b/src/test/java/com/udojava/evalex/TestNested.java
@@ -137,6 +137,20 @@ public class TestNested {
 		}
 		assertEquals("circular reference var", err);
 
+		try {
+			String a = "a";
+			Expression e = new Expression(a);
+			e.with("a", "b");
+			e.with("b", "c");
+			e.with("c", "d");
+			e.with("d", "e");
+			e.with("e", "f");
+			e.with("f", "1");
+			assertEquals("1", e.eval().toString());
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+
 	}
 
 	@Test

--- a/src/test/java/com/udojava/evalex/TestNested.java
+++ b/src/test/java/com/udojava/evalex/TestNested.java
@@ -30,35 +30,35 @@ public class TestNested {
 	@Test
 	public void testvarDefValidation() {
 		String err = "";
-		try {
+        try {
 			String a = "2*x + 4*z";
 			Expression e = new Expression(a);
 			e.eval();
-		} catch (ExpressionException e) {
+        } catch (ExpressionException e) {
 			err = e.getMessage();
-		}
-		assertEquals("unknown var : x", err);
+        }
+        assertEquals("unknown var : x", err);
 
-		try {
+        try {
 			String a = "2*x + 4*z";
 			Expression e = new Expression(a);
 			e.with("x", "1");
 			e.eval();
-		} catch (ExpressionException e) {
+        } catch (ExpressionException e) {
 			err = e.getMessage();
-		}
-		assertEquals("unknown var : z", err);
+        }
+        assertEquals("unknown var : z", err);
 
-		try {
+        try {
 			String a = "2*x + 4*z";
 			Expression e = new Expression(a);
 			e.with("x", "1");
 			e.with("z", "2 * x + z");
 			e.eval();
-		} catch (ExpressionException e) {
+        } catch (ExpressionException e) {
 			err = e.getMessage();
-		}
-		assertEquals("circular reference var", err);
+        }
+        assertEquals("circular reference var : z", err);
 
         try {
 			String a = "x + 2*x + 4*z + y";
@@ -70,7 +70,7 @@ public class TestNested {
         } catch (ExpressionException e) {
 			err = e.getMessage();
         }
-        assertEquals("circular reference var", err);
+        assertEquals("circular reference var : z", err);
 
         try {
 			String a = "2*x + 4*z + y";
@@ -109,22 +109,22 @@ public class TestNested {
         } catch (ExpressionException e) {
 			err = e.getMessage();
         }
-        assertEquals("circular reference var", err);
+        assertEquals("circular reference var : f", err);
 
 		try {
-			String a = "a + b + c + d + e + f";
+			String a = "a + b + c + d + f + g";
 			Expression e = new Expression(a);
 			e.with("a", "b");
 			e.with("b", "c");
 			e.with("c", "d");
-			e.with("d", "e");
-			e.with("e", "f");
-			e.with("f", "a");
+			e.with("d", "f");
+			e.with("f", "g");
+			e.with("g", "a");
 			e.eval();
 		} catch (ExpressionException e) {
 			err = e.getMessage();
 		}
-		assertEquals("circular reference var", err);
+		assertEquals("circular reference var : g", err);
 
 		try {
 			String a = "a + b";
@@ -135,7 +135,7 @@ public class TestNested {
 		} catch (ExpressionException e) {
 			err = e.getMessage();
 		}
-		assertEquals("circular reference var", err);
+		assertEquals("circular reference var : a", err);
 
 		try {
 			String a = "a";

--- a/src/test/java/com/udojava/evalex/TestNested.java
+++ b/src/test/java/com/udojava/evalex/TestNested.java
@@ -70,7 +70,7 @@ public class TestNested {
 		} catch (ExpressionException e) {
 			err = e.getMessage();
 		}
-		assertEquals("circular reference var : z", err);
+		assertEquals("circular reference var : y", err);
 
 		try {
 			String a = "2*x + 4*z + y";
@@ -81,8 +81,48 @@ public class TestNested {
 			assertEquals("15", e.eval().toString());
 		} catch (ExpressionException e) {
 			err = e.getMessage();
-			System.out.println(err);
 		}
+
+		try {
+			String a = "a + b + c + d + e + f";
+			Expression e = new Expression(a);
+			e.with("a", "b");
+			e.with("b", "c");
+			e.with("c", "d");
+			e.with("d", "e");
+			e.with("e", "f");
+			e.with("f", "1");
+			assertEquals("6", e.eval().toString());
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+
+		try {
+			String a = "a + b + c + d + e + f";
+			Expression e = new Expression(a);
+			e.with("a", "b");
+			e.with("b", "c");
+			e.with("c", "d");
+			e.with("d", "e");
+			e.with("e", "f");
+			e.with("f", "a");
+			e.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("circular reference var : a", err);
+
+		try {
+			String a = "a + b";
+			Expression e = new Expression(a);
+			e.with("a", "a + b");
+			e.with("b", "0");
+			e.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("circular reference var : a", err);
+
 	}
 
 	@Test

--- a/src/test/java/com/udojava/evalex/TestNested.java
+++ b/src/test/java/com/udojava/evalex/TestNested.java
@@ -58,32 +58,32 @@ public class TestNested {
 		} catch (ExpressionException e) {
 			err = e.getMessage();
 		}
-		assertEquals("circular reference var : z", err);
+		assertEquals("circular reference var", err);
 
-		try {
-			String a = "2*x + 4*z + y";
+        try {
+			String a = "x + 2*x + 4*z + y";
 			Expression e = new Expression(a);
 			e.with("x", "1");
 			e.with("y", "x * z");
 			e.with("z", "2 * x + y");
 			e.eval();
-		} catch (ExpressionException e) {
+        } catch (ExpressionException e) {
 			err = e.getMessage();
-		}
-		assertEquals("circular reference var : y", err);
+        }
+        assertEquals("circular reference var", err);
 
-		try {
+        try {
 			String a = "2*x + 4*z + y";
 			Expression e = new Expression(a);
 			e.with("x", "1");
 			e.with("y", "x * 1");
 			e.with("z", "2 * x + y");
 			assertEquals("15", e.eval().toString());
-		} catch (ExpressionException e) {
+        } catch (ExpressionException e) {
 			err = e.getMessage();
-		}
+        }
 
-		try {
+        try {
 			String a = "a + b + c + d + e + f";
 			Expression e = new Expression(a);
 			e.with("a", "b");
@@ -93,9 +93,23 @@ public class TestNested {
 			e.with("e", "f");
 			e.with("f", "1");
 			assertEquals("6", e.eval().toString());
-		} catch (ExpressionException e) {
+        } catch (ExpressionException e) {
 			err = e.getMessage();
-		}
+        }
+
+        try {
+			String a = "a + b + c + d + f";
+			Expression e = new Expression(a);
+			e.with("a", "b");
+			e.with("b", "c");
+			e.with("c", "1");
+			e.with("d", "f");
+			e.with("f", "d");
+            e.eval();
+        } catch (ExpressionException e) {
+			err = e.getMessage();
+        }
+        assertEquals("circular reference var", err);
 
 		try {
 			String a = "a + b + c + d + e + f";
@@ -110,7 +124,7 @@ public class TestNested {
 		} catch (ExpressionException e) {
 			err = e.getMessage();
 		}
-		assertEquals("circular reference var : a", err);
+		assertEquals("circular reference var", err);
 
 		try {
 			String a = "a + b";
@@ -121,7 +135,7 @@ public class TestNested {
 		} catch (ExpressionException e) {
 			err = e.getMessage();
 		}
-		assertEquals("circular reference var : a", err);
+		assertEquals("circular reference var", err);
 
 	}
 

--- a/src/test/java/com/udojava/evalex/TestNested.java
+++ b/src/test/java/com/udojava/evalex/TestNested.java
@@ -1,13 +1,14 @@
 package com.udojava.evalex;
 
-import static org.junit.Assert.assertEquals;
-
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.List;
 
+import com.udojava.evalex.Expression.ExpressionException;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class TestNested {
 
@@ -24,6 +25,64 @@ public class TestNested {
 		e.with("z", z);
 
 		assertEquals("34", e.eval().toString());
+	}
+
+	@Test
+	public void testvarDefValidation() {
+		String err = "";
+		try {
+			String a = "2*x + 4*z";
+			Expression e = new Expression(a);
+			e.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("unknown var : x", err);
+
+		try {
+			String a = "2*x + 4*z";
+			Expression e = new Expression(a);
+			e.with("x", "1");
+			e.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("unknown var : z", err);
+
+		try {
+			String a = "2*x + 4*z";
+			Expression e = new Expression(a);
+			e.with("x", "1");
+			e.with("z", "2 * x + z");
+			e.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("circular reference var : z", err);
+
+		try {
+			String a = "2*x + 4*z + y";
+			Expression e = new Expression(a);
+			e.with("x", "1");
+			e.with("y", "x * z");
+			e.with("z", "2 * x + y");
+			e.eval();
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+		}
+		assertEquals("circular reference var : z", err);
+
+		try {
+			String a = "2*x + 4*z + y";
+			Expression e = new Expression(a);
+			e.with("x", "1");
+			e.with("y", "x * 1");
+			e.with("z", "2 * x + y");
+			assertEquals("15", e.eval().toString());
+		} catch (ExpressionException e) {
+			err = e.getMessage();
+			System.out.println(err);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
as the following unit test
```
        @Test
	public void testNestedVars() {
		String x = "1";
		String y = "2";
		String z = "2*x + 3*y";
		String a = "2*x + 4*z";

		Expression e = new Expression(a);
		e.with("x", x);
		e.with("y", y);
		e.with("z", z);

		assertEquals("34", e.eval().toString());
	}
```
if change String x = "y + z";
e.eval() will throw java.lang.StackOverflowError.

we can add evalValidation check before eval to avoid StackOverflowError