### PR TITLE
Unary postfix  operator (squashed commits and fix #255)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,37 @@ e.addOperator(new AbstractOperator(">>", 30, true) {
 e.eval(); // returns 212.34
 ````
 
+Or another example, add a postfix unary operator `n!`, that calculates the factorial of n. The parameters for postfix unary operators are the operator's string, its precedence, if it is left associative, is it is boolean and if it is unary (<code>true</code>).
+
+````java
+Expression e = new Expression("4!");
+
+e.addOperator(new AbstractOperator("!", Expression.OPERATOR_PRECEDENCE_POWER_HIGHER + 1, true, false, true) {
+    @Override
+    public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
+        if(v1 == null) {
+            throw new ArithmeticException("Operand may not be null");
+        }
+        if(v1.remainder(BigDecimal.ONE) != BigDecimal.ZERO) {
+            throw new ArithmeticException("Operand must be an integer");
+        }
+        BigDecimal factorial = v1;
+        v1 = v1.subtract(BigDecimal.ONE);
+        if (factorial.compareTo(BigDecimal.ZERO) == 0 || factorial.compareTo(BigDecimal.ONE) == 0) {
+            return BigDecimal.ONE;
+        } else {
+            while (v1.compareTo(BigDecimal.ONE) > 0) {
+                factorial = factorial.multiply(v1);
+                v1 = v1.subtract(BigDecimal.ONE);
+            }
+            return factorial;
+        }
+    }
+});
+
+e.eval(); // returns 24
+````
+
 ### Add Custom Functions
 
 Adding custom functions is as easy as adding custom operators. Create an instance of `Expression.Function`and add it to the expression.
@@ -255,14 +286,14 @@ Expression e = new Expression("2 * average(12,4,8)");
 e.addFunction(new AbstractFunction("average", -1) {
     @Override
     public BigDecimal eval(List<BigDecimal> parameters) {
-				if (parameters.size() == 0) {
-					throw new ExpressionException("average requires at least one parameter");
-				}
-				BigDecimal avg = new BigDecimal(0);
-				for (BigDecimal parameter : parameters) {
-						avg = avg.add(parameter);
-				}
-				return avg.divide(new BigDecimal(parameters.size()));
+        if (parameters.size() == 0) {
+            throw new ExpressionException("average requires at least one parameter");
+        }
+        BigDecimal avg = new BigDecimal(0);
+        for (BigDecimal parameter : parameters) {
+            avg = avg.add(parameter);
+        }
+        return avg.divide(new BigDecimal(parameters.size()));
     }
 });
 
@@ -287,7 +318,7 @@ e.addLazyFunction(new AbstractLazyFunction("STREQ", 2) {
         public String getString() {
             return "0";
         }
-     };
+    };
     private LazyNumber ONE = new LazyNumber() {
         public BigDecimal eval() {
             return BigDecimal.ONE;

--- a/src/main/java/com/udojava/evalex/AbstractLazyOperator.java
+++ b/src/main/java/com/udojava/evalex/AbstractLazyOperator.java
@@ -30,25 +30,38 @@ package com.udojava.evalex;
  * Abstract implementation of an operator.
  */
 public abstract class AbstractLazyOperator implements LazyOperator {
+	
+	
+	
 	/**
 	 * This operators name (pattern).
 	 */
 	protected String oper;
+	
 	/**
 	 * Operators precedence.
 	 */
 	protected int precedence;
+	
 	/**
 	 * Operator is left associative.
 	 */
 	protected boolean leftAssoc;
+	
 	/**
-	 * Whether this operator is boolean or not.
+	 * Operator is boolean.
 	 */
 	protected boolean booleanOperator = false;
-
+	
 	/**
-	 * Creates a new operator.
+	 * Operator is unary, i.e. 1 or 2 operands expected for this operator.
+	 */
+	protected boolean unaryOperator;
+	
+	
+	
+	/**
+	 * Creates a new unary operator. This constructor allows the use of postfix unary operators.
 	 * 
 	 * @param oper
 	 *            The operator name (pattern).
@@ -56,7 +69,33 @@ public abstract class AbstractLazyOperator implements LazyOperator {
 	 *            The operators precedence.
 	 * @param leftAssoc
 	 *            <code>true</code> if the operator is left associative,
-	 *            else <code>false</code>.
+ 	 *            else <code>false</code>.
+	 * @param booleanOperator
+	 *            Whether this operator is boolean.
+	 * @param unaryOperator
+	 *            <code>true</code> if the expected number of operands is 1,
+ 	 *            <code>false</code> if the expected number of operands is 2.
+	 */
+	protected AbstractLazyOperator(String oper, int precedence, boolean leftAssoc, boolean booleanOperator, boolean unaryOperator) {
+		this.oper = oper;
+		this.precedence = precedence;
+		this.leftAssoc = leftAssoc;
+		this.booleanOperator = booleanOperator;
+		this.unaryOperator = unaryOperator;
+	}
+
+	
+	
+	/**
+	 * Creates a new boolean operator.
+	 * 
+	 * @param oper
+	 *            The operator name (pattern).
+	 * @param precedence
+	 *            The operators precedence.
+	 * @param leftAssoc
+	 *            <code>true</code> if the operator is left associative,
+ 	 *            else <code>false</code>.
 	 * @param booleanOperator
 	 *            Whether this operator is boolean.
 	 */
@@ -65,7 +104,10 @@ public abstract class AbstractLazyOperator implements LazyOperator {
 		this.precedence = precedence;
 		this.leftAssoc = leftAssoc;
 		this.booleanOperator = booleanOperator;
+		this.unaryOperator = false;
 	}
+	
+	
 
 	/**
 	 * Creates a new operator.
@@ -82,21 +124,54 @@ public abstract class AbstractLazyOperator implements LazyOperator {
 		this.oper = oper;
 		this.precedence = precedence;
 		this.leftAssoc = leftAssoc;
+		this.unaryOperator = false;
 	}
 
+	
+	
+	/**
+	 * @return The String that is used to denote the operator in the expression.
+	 */
 	public String getOper() {
 		return oper;
 	}
 
+	
+	
+	/**
+	 * @return the precedence value of this operator.
+	 */
 	public int getPrecedence() {
 		return precedence;
 	}
 
+	
+	
+	/**
+	 * @return <code>true</code> if this operator is left associative.
+	 */
 	public boolean isLeftAssoc() {
 		return leftAssoc;
 	}
 
+
+		
+	/**
+	 * @return <code>true</code> if this operator evaluates to a boolean
+	 *         expression.
+	 */
 	public boolean isBooleanOperator() {
 		return booleanOperator;
 	}
+	
+	
+	
+	/**
+	 * @return <code>true</code> if the number of operands for this operator is 1,
+	 * 			or <code>false</code> if the number of operands is 2.
+	 */
+	public boolean isUnaryOperator() {
+		return unaryOperator;
+	}
+	
 }

--- a/src/main/java/com/udojava/evalex/AbstractOperator.java
+++ b/src/main/java/com/udojava/evalex/AbstractOperator.java
@@ -34,8 +34,32 @@ import com.udojava.evalex.Expression.LazyNumber;
  * Abstract implementation of an operator.
  */
 public abstract class AbstractOperator extends AbstractLazyOperator implements Operator {
+	
+	
+	
 	/**
-	 * Creates a new operator.
+	 * Creates a new unary operator.
+	 * 
+	 * @param oper
+	 *            The operator name (pattern).
+	 * @param precedence
+	 *            The operators precedence.
+	 * @param leftAssoc
+	 *            <code>true</code> if the operator is left associative,
+	 *            else <code>false</code>.
+	 * @param booleanOperator
+	 *            Whether this operator is boolean.
+	 * @param unaryOperator
+	 *            Whether the operator is unary (<code>true</code>) or not (<code>false</code>).
+	 */
+	protected AbstractOperator(String oper, int precedence, boolean leftAssoc, boolean booleanOperator, boolean unaryOperator) {
+		super(oper, precedence, leftAssoc, booleanOperator, unaryOperator);
+	}
+	
+	
+	
+	/**
+	 * Creates a new boolean operator.
 	 * 
 	 * @param oper
 	 *            The operator name (pattern).
@@ -51,6 +75,8 @@ public abstract class AbstractOperator extends AbstractLazyOperator implements O
 		super(oper, precedence, leftAssoc, booleanOperator);
 	}
 
+	
+	
 	/**
 	 * Creates a new operator.
 	 * 
@@ -65,16 +91,42 @@ public abstract class AbstractOperator extends AbstractLazyOperator implements O
 	protected AbstractOperator(String oper, int precedence, boolean leftAssoc) {
 		super(oper, precedence, leftAssoc);
 	}
+	
 
+	
+	/**
+	 * Implementation of this operator supporting either 1 or 2 operands.
+	 * 
+	 * @param v1
+	 * 			The first operand expected for the operation.
+	 * @param v2
+	 * 			The second operand expected for the operation. For postfix unary operators, v2=null condition was added.
+	 * @return
+	 * 			LazyNumber object. The result of the operation.
+	 */
 	public LazyNumber eval(final LazyNumber v1, final LazyNumber v2) {
-		return new LazyNumber() {
-			public BigDecimal eval() {
-				return AbstractOperator.this.eval(v1.eval(), v2.eval());
-			}
-
-			public String getString() {
-				return String.valueOf(AbstractOperator.this.eval(v1.eval(), v2.eval()));
-			}
-		};
+		if(v2 == null) {  // Condition to accept postfix unary operators (e.g. factorial operator '!')
+			return new LazyNumber() {
+				public BigDecimal eval() {
+					return AbstractOperator.this.eval(v1.eval(), null);
+				}
+	
+				public String getString() {
+					return String.valueOf(AbstractOperator.this.eval(v1.eval(), null));
+				}
+			};
+		}
+		else {
+			return new LazyNumber() {
+				public BigDecimal eval() {
+					return AbstractOperator.this.eval(v1.eval(), v2.eval());
+				}
+	
+				public String getString() {
+					return String.valueOf(AbstractOperator.this.eval(v1.eval(), v2.eval()));
+				}
+			};
+		}
 	}
+	
 }

--- a/src/main/java/com/udojava/evalex/AbstractUnaryOperator.java
+++ b/src/main/java/com/udojava/evalex/AbstractUnaryOperator.java
@@ -39,6 +39,7 @@ import com.udojava.evalex.Expression.LazyNumber;
  */
 public abstract class AbstractUnaryOperator extends AbstractOperator {
 
+
 	/**
 	 * Creates a new operator.
 	 * 
@@ -53,6 +54,7 @@ public abstract class AbstractUnaryOperator extends AbstractOperator {
 	protected AbstractUnaryOperator(String oper, int precedence, boolean leftAssoc) {
 		super(oper, precedence, leftAssoc);
 	}
+
 
 	@Override
 	public LazyNumber eval(final LazyNumber v1, final LazyNumber v2) {
@@ -72,6 +74,16 @@ public abstract class AbstractUnaryOperator extends AbstractOperator {
 		};
 	}
 
+
+	/**
+	 * Implementation of this operator calling unary operator evaluation method..
+	 * 
+	 * @param v1
+	 *            The first parameter.
+	 * @param v2
+	 *            The second parameter. Expected to be null
+	 * @return The result of the operation.
+	 */
 	public BigDecimal eval(BigDecimal v1, BigDecimal v2) {
 		if (v2 != null) {
 			throw new ExpressionException("Did not expect a second parameter for unary operator");
@@ -79,8 +91,9 @@ public abstract class AbstractUnaryOperator extends AbstractOperator {
 		return evalUnary(v1);
 	}
 
+
 	/**
-	 * Implementation of this unary operator.
+	 * Implementation of this prefix unary operator.
 	 * 
 	 * @param v1
 	 *            The parameter.

--- a/src/main/java/com/udojava/evalex/LazyOperator.java
+++ b/src/main/java/com/udojava/evalex/LazyOperator.java
@@ -33,6 +33,8 @@ import com.udojava.evalex.Expression.LazyNumber;
  */
 public interface LazyOperator {
 
+	
+	
 	/**
 	 * Gets the String that is used to denote the operator in the expression.
 	 * 
@@ -40,6 +42,8 @@ public interface LazyOperator {
 	 */
 	public abstract String getOper();
 
+	
+	
 	/**
 	 * Gets the precedence value of this operator.
 	 * 
@@ -47,6 +51,8 @@ public interface LazyOperator {
 	 */
 	public abstract int getPrecedence();
 
+	
+	
 	/**
 	 * Gets whether this operator is left associative (<code>true</code>) or if
 	 * this operator is right associative (<code>false</code>).
@@ -55,13 +61,28 @@ public interface LazyOperator {
 	 */
 	public abstract boolean isLeftAssoc();
 	
+	
+	
 	/**
 	 * Gets whether this operator evaluates to a boolean expression.
+	 * 
 	 * @return <code>true</code> if this operator evaluates to a boolean
 	 *         expression.
 	 */
 	public abstract boolean isBooleanOperator();
+	
+	
+	
+	/**
+	 * Gets whether this operator is unary or not.
+	 * 
+	 * @return <code>true</code> if this operator expects 1 operand, otherwise
+	 * 			<code>false</code> if this operator expects 2 operands.
+	 */
+	public abstract boolean isUnaryOperator();	
 
+
+	
 	/**
 	 * Implementation for this operator.
 	 * 
@@ -69,6 +90,7 @@ public interface LazyOperator {
 	 *            Operand 1.
 	 * @param v2
 	 *            Operand 2.
+	 *            
 	 * @return The result of the operation.
 	 */
 	public abstract LazyNumber eval(LazyNumber v1, LazyNumber v2);

--- a/src/main/java/com/udojava/evalex/Operator.java
+++ b/src/main/java/com/udojava/evalex/Operator.java
@@ -29,16 +29,20 @@ package com.udojava.evalex;
 import java.math.BigDecimal;
 
 /**
- * Base interface which is required for all operators.
+ * Base interface which is required for all operators. Abstract class AbstractOperator accepts
+ * postfix unary operators with the second operand v2=null.
  */
 public interface Operator extends LazyOperator {
+	
+	
+	
 	/**
 	 * Implementation for this operator.
 	 * 
 	 * @param v1
 	 *            Operand 1.
 	 * @param v2
-	 *            Operand 2.
+	 *            Operand 2. Null for postfix unary operators.
 	 * @return The result of the operation.
 	 */
 	public abstract BigDecimal eval(BigDecimal v1, BigDecimal v2);

--- a/src/test/java/com/udojava/evalex/TestExposedComponents.java
+++ b/src/test/java/com/udojava/evalex/TestExposedComponents.java
@@ -69,4 +69,3 @@ public class TestExposedComponents {
         expression.getDeclaredVariables().add("$$$");
     }
 }
-


### PR DESCRIPTION
Hi,

I closed the pull request #255 and, as per the author's request, squashed all commits.

The build errors seemed to be caused because the files ```TestCustoms.java```, ```TestExposedComponents.java```, ```TestNested.java``` and ```TestTokenizer.java``` were not updated with the necessary information for the ```new Operator()``` constructors. This has now been fixed.

Regards.


############################## ORIGINAL MESSAGE ##############################


So, I saw that this subject has already been discussed on issues #126, #180 and #236, but since my previous code already used custom/user-defined operators, I went ahead and decided to modify the AbstractOperator and Expression classes, so they were able to handle **postfix unary operators** (e.g. "!" operator for factorial function) without throwing exceptions. However, I did not exclude the AbstractUnaryOperator class or joined it with the AbstractOperator class through the modifications herein. Therefore, the **prefix unary operators** are still defined by the AbstractUnaryOperator class.

In general lines, I added an `int` parameter in the AbstractOperator and AbstractLazyOperator class methods called "numberOperands" to keep track of the number of operands this operator expects (e.g. numberOperands=1 for "!" and numberOperands=2 for "^"). The method ```getNumberOperands()``` below was added to the LazyOperator and AbstractLazyOperator classes, associated with a ```protected int numberOperands``` variable. This value could later be called and used whenever necessary to check which type of operator is being used.

```java
public int getNumberOfOperands(){
	return numberOperands;
}
```

With the above, the Expression class was edited at some points to understand and handle double-operand operators and postfix unary operators based on this ```numberOperands``` parameter, still classifying all as ```TokenType.OPERATOR```, accepting the second operand ```v2=null``` without exceptions. As an example, when attributing the token types, a condition was added such that a postfix unary operator followed by a regular operator would not classify the later as a *prefix unary operator*, i.e. when analyzing the expression ```"4!+2"``` the operator "+" would not be classified as ```TokenType.UNARY_OPERATOR``` but rather ```TokenType.OPERATOR``` accepting it as a *postfix unary operator*, yielding the correct result ```4!+2 = 26```. It is crucial to notice that a sufficiently high precedence number must be passed when declaring the new AbstractOperator to avoid misinterpretations (e.g. I used precedence "Expression.OPERATOR_PRECEDENCE_POWER_HIGHER + 1" to the added postfix unary operators).

The expression evaluation has shown the correct results for the tests I have run so far, with different expressions and postfix unary operators. However, if any mistakes were made or some logical error I have not noticed, please let me know. For now, I didn't want to change the implementation for the prefix unary operators, but if the solution presented holds, I would gladly make changes to join all operators in a single class.