### PR TITLE
Add JPMS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 sudo: false
 install: true
+jdk: openjdk9
 addons:
   sonarcloud:
     organization: uklimaschewski

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,31 @@
           <target>1.6</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <version>1.0.0.RC2</version>
+        <executions>
+          <execution>
+            <id>add-module-info</id>
+            <phase>package</phase>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+              <jvmVersion>base</jvmVersion>
+              <module>
+                <moduleInfo>
+                  <name>com.udojava.evalex</name>
+                  <exports>
+                    com.udojava.evalex;
+                  </exports>
+                </moduleInfo>
+              </module>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Alter `pom.xml` to generate a `module-info.class`. All other class files still target Java 6. This allows the use of EvalEx with jlink out of the box.

If I'm reading the documentation right, JDK 9 availability varies depending on the Travis CI environment. This means it may be necessary to change `.travis.yml` to install the right JDK version -- let me know.