### PR TITLE
add module-info from source file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
           <target>1.6</target>
         </configuration>
       </plugin>
-      <!-- Disabled, as this is not working correctly
       <plugin>
         <groupId>org.moditect</groupId>
         <artifactId>moditect-maven-plugin</artifactId>
@@ -91,20 +90,16 @@
               <goal>add-module-info</goal>
             </goals>
             <configuration>
-              <jvmVersion>base</jvmVersion>
+              <jvmVersion>9</jvmVersion>
               <module>
-                <moduleInfo>
-                  <name>com.udojava.evalex</name>
-                  <exports>
-                    com.udojava.evalex;
-                  </exports>
-                </moduleInfo>
+                <moduleInfoFile>
+                  ${project.basedir}/src/main/java9/module-info.java
+                </moduleInfoFile>
               </module>
             </configuration>
           </execution>
         </executions>
       </plugin>
-      -->
     </plugins>
   </build>
 

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -1,0 +1,3 @@
+module com.udojava.evalex {
+    exports com.udojava.evalex;
+}


### PR DESCRIPTION
This is meant to address the build failure resulting from #270. That PR specified the contents of `module-info.java` as part of the POM. For reasons unclear to me, this causes the moditect plugin to invoke jdeps and generate a module descriptor in addition to the one specified in the POM.

This PR replaces the `<moduleInfo>` element with a reference to a java source file. Configuring moditect in this way is not only considerably less ugly than writing the module descriptor in XML, but also prevents the plugin from running jdeps.

Build works for me on OpenJDK 11.0.2, and both Maven 3.6.3 and 3.8.3. I'm unable to verify whether or not it'll work with the `publish` profile.