### PR TITLE
Omit `NULL` from `getUsedVariables()` output

### DIFF
--- a/src/main/java/com/udojava/evalex/Expression.java
+++ b/src/main/java/com/udojava/evalex/Expression.java
@@ -34,6 +34,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -195,6 +196,17 @@ public class Expression {
    */
   private static final char MINUS_SIGN = '-';
 
+  /**
+   * A map of symbols that stand for constant values. These are not considered variables by {@link #getUsedVariables()}.
+   */
+  private static final Map<String, BigDecimal> DEFAULT_CONSTANTS = new HashMap<String, BigDecimal>();
+  static {
+    DEFAULT_CONSTANTS.put("e",     e);
+    DEFAULT_CONSTANTS.put("PI",    PI);
+    DEFAULT_CONSTANTS.put("NULL",  null);
+    DEFAULT_CONSTANTS.put("TRUE",  BigDecimal.ONE);
+    DEFAULT_CONSTANTS.put("FALSE", BigDecimal.ZERO);
+  }
 
   /**
    * The BigDecimal representation of the left parenthesis, used for parsing varying numbers of
@@ -1259,12 +1271,10 @@ public class Expression {
       }
     });
 
-    variables.put("e", createLazyNumber(e));
-    variables.put("PI", createLazyNumber(PI));
-    variables.put("NULL", null);
-    variables.put("TRUE", createLazyNumber(BigDecimal.ONE));
-    variables.put("FALSE", createLazyNumber(BigDecimal.ZERO));
-
+    for (Map.Entry<String, BigDecimal> constant : DEFAULT_CONSTANTS.entrySet()) {
+      BigDecimal value = constant.getValue();
+      variables.put(constant.getKey(), value == null? null : createLazyNumber(value));
+    }
   }
 
 
@@ -2080,9 +2090,7 @@ public class Expression {
     while (tokenizer.hasNext()) {
       Token nextToken = tokenizer.next();
       String token = nextToken.toString();
-      if (nextToken.type != TokenType.VARIABLE || token.equals("PI") || token.equals("e") || token
-          .equals("TRUE")
-          || token.equals("FALSE")) {
+      if (nextToken.type != TokenType.VARIABLE || DEFAULT_CONSTANTS.containsKey(token)) {
         continue;
       }
       result.add(token);

--- a/src/test/java/com/udojava/evalex/TestConstants.java
+++ b/src/test/java/com/udojava/evalex/TestConstants.java
@@ -1,0 +1,51 @@
+package com.udojava.evalex;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class TestConstants {
+  private final String     constantName;
+  private final BigDecimal constantValue;
+
+  public TestConstants(String constantName, BigDecimal value) {
+    this.constantName  = constantName;
+    this.constantValue = value;
+  }
+
+  @Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+      new Object[]{"e",     Expression.e},
+      new Object[]{"PI",    Expression.PI},
+      new Object[]{"TRUE",  BigDecimal.ONE},
+      new Object[]{"FALSE", BigDecimal.ZERO},
+      new Object[]{"NULL",  null}
+      );
+  }
+
+  @Test
+  public void testEvaluateConstants() {
+    assertEquals(
+      constantValue,
+      new Expression(constantName)
+        .setPrecision(MathContext.UNLIMITED.getPrecision())
+        .eval()
+    );
+  }
+
+  @Test
+  public void testConstantsAreNotVars() {
+    assertTrue(new Expression(constantName).getUsedVariables().isEmpty());
+  }
+}


### PR DESCRIPTION
Fixes #238. Moves all constants to a map to avoid the code duplication that causes errors of this nature. Includes tests.