### PR TITLE
Fix string tokenization

### DIFF
--- a/src/main/java/com/udojava/evalex/TokenizerException.java
+++ b/src/main/java/com/udojava/evalex/TokenizerException.java
@@ -1,0 +1,7 @@
+package com.udojava.evalex;
+
+public class TokenizerException extends Expression.ExpressionException {
+    public TokenizerException(String message, int characterPosition) {
+        super(message, characterPosition);
+    }
+}

--- a/src/test/java/com/udojava/evalex/TestGetUsedVariables.java
+++ b/src/test/java/com/udojava/evalex/TestGetUsedVariables.java
@@ -3,6 +3,8 @@ package com.udojava.evalex;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 
@@ -32,5 +34,12 @@ public class TestGetUsedVariables {
     Expression ex = new Expression("1/2");
     List<String> usedVars = ex.getUsedVariables();
     assertEquals(0, usedVars.size());
+  }
+
+  @Test
+  public void testStringComparison() {
+    // test for issue #267 (getUsedVariables() throws NPE in expressions containing string literals)
+    Expression ex = new Expression("foo=\"bar\"").setVariable("foo", (BigDecimal) null);
+    assertEquals(Collections.singletonList("foo"), ex.getUsedVariables());
   }
 }

--- a/src/test/java/com/udojava/evalex/TestTokenizer.java
+++ b/src/test/java/com/udojava/evalex/TestTokenizer.java
@@ -1,15 +1,18 @@
 package com.udojava.evalex;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import com.udojava.evalex.Expression.Token;
 import com.udojava.evalex.Expression.TokenType;
 import java.math.BigDecimal;
 import java.util.Iterator;
+
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 
 public class TestTokenizer {
@@ -365,4 +368,24 @@ public class TestTokenizer {
     BigDecimal result = e.with("a", "0").and("b", "0").eval();
     assertEquals("0", result.toPlainString());
   }
+
+  @Test
+  public void testStringLiterals() {
+    Iterator<Token> i = new Expression("\"foo\"").getExpressionTokenizer();
+    assertEquals(TokenType.STRINGPARAM, i.next().type);
+    assertFalse(i.hasNext());
+  }
+
+  @Test
+  public void testUnterminatedStringLiterals() {
+    TokenizerException ex = assertThrows(TokenizerException.class, new ThrowingRunnable() {
+      @Override
+      public void run() {
+        new Expression("\"foo").getExpressionTokenizer().next();
+      }
+    });
+
+    assertEquals("unterminated string literal at character position 0", ex.getMessage());
+  }
+
 }


### PR DESCRIPTION
Fixes #267. The tokenizer previously did not consume closing quotes in string literals until the following call to `next()`. This meant that the tokenizer always behaved as though there was more input to consume after a string literal. If the last token in an expression was a string literal, upon reaching the end of the expression `hasNext()` erroneously returned `true`, and the subsequent call to `next()` produced an empty token with type null.

This PR includes some minor refactoring of tokenizer code to make it less repetitious and easier to read. Lines that manipulate the tokenizer position and token content have been replaced with the methods `consumeChar()` and `skipChar()`. It also adds a new `TokenizerException`; this inherits from `ExpressionException` so as to not break existing exception handlers.

Note that the new string logic will change the behaviour of strings slightly: literals without closing quotation marks will cause a `TokenizerException`.