### PR TITLE
Fix issue #557: Bad result on boolean operators involving undefined variables when lenient mode enabled

### DIFF
--- a/src/main/java/com/ezylang/evalex/data/EvaluationValue.java
+++ b/src/main/java/com/ezylang/evalex/data/EvaluationValue.java
@@ -318,7 +318,7 @@ public class EvaluationValue implements Comparable<EvaluationValue> {
   }
 
   public boolean isNullValue() {
-    return getDataType() == DataType.NULL;
+    return getDataType() == DataType.NULL || getDataType() == DataType.UNDEFINED;
   }
 
   /**
@@ -390,6 +390,8 @@ public class EvaluationValue implements Comparable<EvaluationValue> {
         return ((BigDecimal) value).toPlainString();
       case NULL:
         return null;
+      case UNDEFINED:
+        return "";
       default:
         return value.toString();
     }
@@ -538,6 +540,8 @@ public class EvaluationValue implements Comparable<EvaluationValue> {
         return getDateTimeValue().compareTo(toCompare.getDateTimeValue());
       case DURATION:
         return getDurationValue().compareTo(toCompare.getDurationValue());
+      case UNDEFINED:
+        throw new NullPointerException("Can not compare an undefined value");
       default:
         return getStringValue().compareTo(toCompare.getStringValue());
     }

--- a/src/main/java/com/ezylang/evalex/operators/booleans/InfixEqualsOperator.java
+++ b/src/main/java/com/ezylang/evalex/operators/booleans/InfixEqualsOperator.java
@@ -30,11 +30,11 @@ public class InfixEqualsOperator extends AbstractOperator {
   @Override
   public EvaluationValue evaluate(
       Expression expression, Token operatorToken, EvaluationValue... operands) {
-    if (operands[0].getDataType() != operands[1].getDataType()) {
-      return EvaluationValue.FALSE;
-    }
     if (operands[0].isNullValue() && operands[1].isNullValue()) {
       return EvaluationValue.TRUE;
+    }
+    if (operands[0].getDataType() != operands[1].getDataType()) {
+      return EvaluationValue.FALSE;
     }
     return expression.convertValue(operands[0].compareTo(operands[1]) == 0);
   }

--- a/src/main/java/com/ezylang/evalex/operators/booleans/InfixNotEqualsOperator.java
+++ b/src/main/java/com/ezylang/evalex/operators/booleans/InfixNotEqualsOperator.java
@@ -30,11 +30,11 @@ public class InfixNotEqualsOperator extends AbstractOperator {
   @Override
   public EvaluationValue evaluate(
       Expression expression, Token operatorToken, EvaluationValue... operands) {
-    if (operands[0].getDataType() != operands[1].getDataType()) {
-      return EvaluationValue.TRUE;
-    }
     if (operands[0].isNullValue() && operands[1].isNullValue()) {
       return EvaluationValue.FALSE;
+    }
+    if (operands[0].getDataType() != operands[1].getDataType()) {
+      return EvaluationValue.TRUE;
     }
     return expression.convertValue(operands[0].compareTo(operands[1]) != 0);
   }

--- a/src/test/java/com/ezylang/evalex/config/TestConfigurationProvider.java
+++ b/src/test/java/com/ezylang/evalex/config/TestConfigurationProvider.java
@@ -30,6 +30,13 @@ import java.util.Map;
 
 public class TestConfigurationProvider {
 
+  public static final ExpressionConfiguration StandardConfigurationLenient =
+      ExpressionConfiguration.builder()
+          .zoneId(ZoneId.of("Europe/Berlin"))
+          .locale(Locale.US)
+          .lenientMode(true)
+          .build();
+
   public static final ExpressionConfiguration StandardConfigurationWithAdditionalTestOperators =
       ExpressionConfiguration.builder()
           .zoneId(ZoneId.of("Europe/Berlin"))

--- a/src/test/java/com/ezylang/evalex/operators/booleans/InfixAndOperatorTest.java
+++ b/src/test/java/com/ezylang/evalex/operators/booleans/InfixAndOperatorTest.java
@@ -15,9 +15,14 @@
 */
 package com.ezylang.evalex.operators.booleans;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.ezylang.evalex.BaseEvaluationTest;
 import com.ezylang.evalex.EvaluationException;
+import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.config.TestConfigurationProvider;
 import com.ezylang.evalex.parser.ParseException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -42,5 +47,22 @@ class InfixAndOperatorTest extends BaseEvaluationTest {
   void testInfixLessLiterals(String expression, String expectedResult)
       throws EvaluationException, ParseException {
     assertExpressionHasExpectedResult(expression, expectedResult);
+  }
+
+  @Test
+  void testInfixAndVariablesLenient() throws EvaluationException, ParseException {
+    Expression expression =
+        new Expression("a&&true", TestConfigurationProvider.StandardConfigurationLenient);
+
+    assertThat(expression.evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", "").evaluate().getBooleanValue()).isFalse();
+
+    Expression expression2 =
+        new Expression("a&&false", TestConfigurationProvider.StandardConfigurationLenient);
+
+    assertThat(expression2.evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression2.with("a", "").evaluate().getBooleanValue()).isFalse();
   }
 }

--- a/src/test/java/com/ezylang/evalex/operators/booleans/InfixEqualsOperatorTest.java
+++ b/src/test/java/com/ezylang/evalex/operators/booleans/InfixEqualsOperatorTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.ezylang.evalex.BaseEvaluationTest;
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.config.TestConfigurationProvider;
 import com.ezylang.evalex.parser.ParseException;
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -94,6 +95,28 @@ class InfixEqualsOperatorTest extends BaseEvaluationTest {
     assertThat(expression.with("a", true).and("b", true).evaluate().getBooleanValue()).isTrue();
 
     assertThat(expression.with("a", false).and("b", true).evaluate().getBooleanValue()).isFalse();
+  }
+
+  @Test
+  void testInfixEqualsVariablesLenientMode() throws EvaluationException, ParseException {
+    Expression expression =
+        new Expression("a=b", TestConfigurationProvider.StandardConfigurationLenient);
+
+    assertThat(expression.evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", null).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", "").evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", "Hello").evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", new BigDecimal(0)).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", new BigDecimal(1)).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", false).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", true).evaluate().getBooleanValue()).isFalse();
   }
 
   @Test

--- a/src/test/java/com/ezylang/evalex/operators/booleans/InfixGreaterEqualsOperatorTest.java
+++ b/src/test/java/com/ezylang/evalex/operators/booleans/InfixGreaterEqualsOperatorTest.java
@@ -15,9 +15,18 @@
 */
 package com.ezylang.evalex.operators.booleans;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.ezylang.evalex.BaseEvaluationTest;
 import com.ezylang.evalex.EvaluationException;
+import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.config.TestConfigurationProvider;
 import com.ezylang.evalex.parser.ParseException;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -49,5 +58,50 @@ class InfixGreaterEqualsOperatorTest extends BaseEvaluationTest {
   void testInfixGreaterEqualsLiterals(String expression, String expectedResult)
       throws EvaluationException, ParseException {
     assertExpressionHasExpectedResult(expression, expectedResult);
+  }
+
+  @Test
+  void testInfixGreaterEqualsVariablesLenient() throws EvaluationException, ParseException {
+    Expression expression =
+        new Expression("a>=b", TestConfigurationProvider.StandardConfigurationLenient);
+
+    assertThatThrownBy(() -> expression.evaluate())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Can not compare an undefined value");
+
+    assertThat(expression.with("a", "").evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", "Hello").evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", new BigDecimal(-1)).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", new BigDecimal(0)).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", new BigDecimal(1)).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", false).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", true).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(
+            expression
+                .with("a", Instant.parse("2026-02-25T00:00:00Z"))
+                .evaluate()
+                .getBooleanValue())
+        .isTrue();
+
+    assertThat(
+            expression
+                .with("b", Instant.parse("2026-02-25T00:00:00Z"))
+                .evaluate()
+                .getBooleanValue())
+        .isTrue();
+
+    assertThat(expression.with("a", Duration.parse("PT0S")).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", Duration.parse("PT1H")).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", Duration.parse("PT-1H")).evaluate().getBooleanValue())
+        .isFalse();
   }
 }

--- a/src/test/java/com/ezylang/evalex/operators/booleans/InfixGreaterOperatorTest.java
+++ b/src/test/java/com/ezylang/evalex/operators/booleans/InfixGreaterOperatorTest.java
@@ -15,9 +15,18 @@
 */
 package com.ezylang.evalex.operators.booleans;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.ezylang.evalex.BaseEvaluationTest;
 import com.ezylang.evalex.EvaluationException;
+import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.config.TestConfigurationProvider;
 import com.ezylang.evalex.parser.ParseException;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -45,5 +54,46 @@ class InfixGreaterOperatorTest extends BaseEvaluationTest {
   void testInfixGreaterLiterals(String expression, String expectedResult)
       throws EvaluationException, ParseException {
     assertExpressionHasExpectedResult(expression, expectedResult);
+  }
+
+  @Test
+  void testInfixGreaterVariablesLenient() throws EvaluationException, ParseException {
+    Expression expression =
+        new Expression("a>b", TestConfigurationProvider.StandardConfigurationLenient);
+
+    assertThatThrownBy(() -> expression.evaluate())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Can not compare an undefined value");
+
+    assertThat(expression.with("a", "").evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", "Hello").evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", new BigDecimal(0)).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", new BigDecimal(1)).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", false).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", true).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(
+            expression
+                .with("a", Instant.parse("2026-02-25T00:00:00Z"))
+                .evaluate()
+                .getBooleanValue())
+        .isTrue();
+
+    assertThat(
+            expression
+                .with("b", Instant.parse("2026-02-25T00:00:00Z"))
+                .evaluate()
+                .getBooleanValue())
+        .isFalse();
+
+    assertThat(expression.with("a", Duration.parse("PT1H")).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", Duration.parse("PT-1H")).evaluate().getBooleanValue())
+        .isFalse();
   }
 }

--- a/src/test/java/com/ezylang/evalex/operators/booleans/InfixLessEqualsOperatorTest.java
+++ b/src/test/java/com/ezylang/evalex/operators/booleans/InfixLessEqualsOperatorTest.java
@@ -15,9 +15,18 @@
 */
 package com.ezylang.evalex.operators.booleans;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.ezylang.evalex.BaseEvaluationTest;
 import com.ezylang.evalex.EvaluationException;
+import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.config.TestConfigurationProvider;
 import com.ezylang.evalex.parser.ParseException;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -49,5 +58,49 @@ class InfixLessEqualsOperatorTest extends BaseEvaluationTest {
   void testInfixLessEqualsLiterals(String expression, String expectedResult)
       throws EvaluationException, ParseException {
     assertExpressionHasExpectedResult(expression, expectedResult);
+  }
+
+  @Test
+  void testInfixLessEqualsVariablesLenient() throws EvaluationException, ParseException {
+    Expression expression =
+        new Expression("a<=b", TestConfigurationProvider.StandardConfigurationLenient);
+
+    assertThatThrownBy(() -> expression.evaluate())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Can not compare an undefined value");
+
+    assertThat(expression.with("a", "").evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", "Hello").evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", new BigDecimal(-1)).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", new BigDecimal(0)).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", new BigDecimal(1)).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", false).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", true).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(
+            expression
+                .with("a", Instant.parse("2026-02-25T00:00:00Z"))
+                .evaluate()
+                .getBooleanValue())
+        .isFalse();
+
+    assertThat(
+            expression
+                .with("b", Instant.parse("2026-02-25T00:00:00Z"))
+                .evaluate()
+                .getBooleanValue())
+        .isTrue();
+
+    assertThat(expression.with("a", Duration.parse("PT1H")).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", Duration.parse("PT0H")).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", Duration.parse("PT-1H")).evaluate().getBooleanValue()).isTrue();
   }
 }

--- a/src/test/java/com/ezylang/evalex/operators/booleans/InfixLessOperatorTest.java
+++ b/src/test/java/com/ezylang/evalex/operators/booleans/InfixLessOperatorTest.java
@@ -15,9 +15,18 @@
 */
 package com.ezylang.evalex.operators.booleans;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.ezylang.evalex.BaseEvaluationTest;
 import com.ezylang.evalex.EvaluationException;
+import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.config.TestConfigurationProvider;
 import com.ezylang.evalex.parser.ParseException;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -47,5 +56,47 @@ class InfixLessOperatorTest extends BaseEvaluationTest {
   void testInfixLessLiterals(String expression, String expectedResult)
       throws EvaluationException, ParseException {
     assertExpressionHasExpectedResult(expression, expectedResult);
+  }
+
+  @Test
+  void testInfixLessVariablesLenient() throws EvaluationException, ParseException {
+    Expression expression =
+        new Expression("a<b", TestConfigurationProvider.StandardConfigurationLenient);
+
+    assertThatThrownBy(() -> expression.evaluate())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Can not compare an undefined value");
+
+    assertThat(expression.with("a", "").evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", "Hello").evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", new BigDecimal(-1)).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", new BigDecimal(0)).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", new BigDecimal(1)).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", false).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", true).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(
+            expression
+                .with("a", Instant.parse("2026-02-25T00:00:00Z"))
+                .evaluate()
+                .getBooleanValue())
+        .isFalse();
+
+    assertThat(
+            expression
+                .with("b", Instant.parse("2026-02-25T00:00:00Z"))
+                .evaluate()
+                .getBooleanValue())
+        .isFalse();
+
+    assertThat(expression.with("a", Duration.parse("PT1H")).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", Duration.parse("PT-1H")).evaluate().getBooleanValue()).isTrue();
   }
 }

--- a/src/test/java/com/ezylang/evalex/operators/booleans/InfixNotEqualsOperatorTest.java
+++ b/src/test/java/com/ezylang/evalex/operators/booleans/InfixNotEqualsOperatorTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.ezylang.evalex.BaseEvaluationTest;
 import com.ezylang.evalex.EvaluationException;
 import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.config.TestConfigurationProvider;
 import com.ezylang.evalex.parser.ParseException;
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -94,6 +95,28 @@ class InfixNotEqualsOperatorTest extends BaseEvaluationTest {
     assertThat(expression.with("a", true).and("b", true).evaluate().getBooleanValue()).isFalse();
 
     assertThat(expression.with("a", false).and("b", true).evaluate().getBooleanValue()).isTrue();
+  }
+
+  @Test
+  void testInfixNotEqualsVariablesLenient() throws EvaluationException, ParseException {
+    Expression expression =
+        new Expression("a!=b", TestConfigurationProvider.StandardConfigurationLenient);
+
+    assertThat(expression.evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", null).evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression.with("a", "").evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", "Hello").evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", new BigDecimal(0)).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", new BigDecimal(1)).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", false).evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", true).evaluate().getBooleanValue()).isTrue();
   }
 
   @Test

--- a/src/test/java/com/ezylang/evalex/operators/booleans/InfixOrOperatorTest.java
+++ b/src/test/java/com/ezylang/evalex/operators/booleans/InfixOrOperatorTest.java
@@ -15,9 +15,14 @@
 */
 package com.ezylang.evalex.operators.booleans;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.ezylang.evalex.BaseEvaluationTest;
 import com.ezylang.evalex.EvaluationException;
+import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.config.TestConfigurationProvider;
 import com.ezylang.evalex.parser.ParseException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -44,5 +49,22 @@ class InfixOrOperatorTest extends BaseEvaluationTest {
   void testInfixLessLiterals(String expression, String expectedResult)
       throws EvaluationException, ParseException {
     assertExpressionHasExpectedResult(expression, expectedResult);
+  }
+
+  @Test
+  void testInfixOrVariablesLenient() throws EvaluationException, ParseException {
+    Expression expression =
+        new Expression("a||true", TestConfigurationProvider.StandardConfigurationLenient);
+
+    assertThat(expression.evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", "").evaluate().getBooleanValue()).isTrue();
+
+    Expression expression2 =
+        new Expression("a||false", TestConfigurationProvider.StandardConfigurationLenient);
+
+    assertThat(expression2.evaluate().getBooleanValue()).isFalse();
+
+    assertThat(expression2.with("a", "").evaluate().getBooleanValue()).isFalse();
   }
 }

--- a/src/test/java/com/ezylang/evalex/operators/booleans/PrefixNotOperatorTest.java
+++ b/src/test/java/com/ezylang/evalex/operators/booleans/PrefixNotOperatorTest.java
@@ -15,9 +15,14 @@
 */
 package com.ezylang.evalex.operators.booleans;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.ezylang.evalex.BaseEvaluationTest;
 import com.ezylang.evalex.EvaluationException;
+import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.config.TestConfigurationProvider;
 import com.ezylang.evalex.parser.ParseException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -39,5 +44,15 @@ class PrefixNotOperatorTest extends BaseEvaluationTest {
   void testInfixLessLiterals(String expression, String expectedResult)
       throws EvaluationException, ParseException {
     assertExpressionHasExpectedResult(expression, expectedResult);
+  }
+
+  @Test
+  void testInfixNotVariablesLenient() throws EvaluationException, ParseException {
+    Expression expression =
+        new Expression("!a", TestConfigurationProvider.StandardConfigurationLenient);
+
+    assertThat(expression.evaluate().getBooleanValue()).isTrue();
+
+    assertThat(expression.with("a", "").evaluate().getBooleanValue()).isTrue();
   }
 }


### PR DESCRIPTION
This solves the reported issues #511 and #557.